### PR TITLE
Fix permission on relog

### DIFF
--- a/Classes/FlickrKit/FlickrKit.m
+++ b/Classes/FlickrKit/FlickrKit.m
@@ -295,9 +295,9 @@
 						completion(nil, nil, nil, error);
 					}
 				} else {
-					[[NSUserDefaults standardUserDefaults] setValue:oat forKey:kFKStoredTokenKey];
-					[[NSUserDefaults standardUserDefaults] setValue:oats forKey:kFKStoredTokenSecret];
-					[[NSUserDefaults standardUserDefaults] setValue:@(self.permissionGranted) forKey:kFKStoredTokenPermission];
+					[[NSUserDefaults standardUserDefaults] setObject:oat forKey:kFKStoredTokenKey];
+					[[NSUserDefaults standardUserDefaults] setObject:oats forKey:kFKStoredTokenSecret];
+					[[NSUserDefaults standardUserDefaults] setObject:@(self.permissionGranted) forKey:kFKStoredTokenPermission];
 					[[NSUserDefaults standardUserDefaults] synchronize];
 					self.authorized = YES;
 					self.authToken = oat;


### PR DESCRIPTION
Previously the `permissionGranted` attribute was set only in `userAuthorizationURLWithRequestToken:requestedPermission:`. But this method is not called when using `checkAuthorizationOnCompletion:`. Thus, requests that require write or delete permission failed when using a token from a previous authentication procedure.

This pull request stores the `grantedPermission` attribute along with the auth token in the NSUserDefaults, and restores it when `checkAuthorizationOnCompletion:` succeeds.
