### PR TITLE
Fix 'unrecognized selector' error in case auth token request fails

### DIFF
--- a/Classes/FlickrKit/FlickrKit.m
+++ b/Classes/FlickrKit/FlickrKit.m
@@ -211,8 +211,12 @@
 			NSString *oat = params[@"oauth_token"];
 			NSString *oats = params[@"oauth_token_secret"];
 			if (!oat || !oats) {
-				
-				NSDictionary *userInfo = @{NSLocalizedDescriptionKey: response};
+				NSInteger statusCode = -1;
+				if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+					statusCode = ((NSHTTPURLResponse*)response).statusCode;
+				}
+				NSString* errorDescription = [NSString stringWithFormat:@"Unexpected response from server: %d", statusCode];
+				NSDictionary *userInfo = @{NSLocalizedDescriptionKey: errorDescription};
 				NSError *error = [NSError errorWithDomain:FKFlickrKitErrorDomain code:FKErrorAuthenticating userInfo:userInfo];
 				if (completion) {
 					completion(nil, error);


### PR DESCRIPTION
Previously, the NSError generated by beginAuthWithCallbackURL:... if auth token or secret are missing sets the NSURLResponse object as NSLocalizedDescriptionKey. According to the docs, the object associated with NSLocalizedDescriptionKey must be a string. In particular, if you called -[NSError localizedDescription] on the object, a "unrecongnized selector 'length' sent to instance NSError" error occurred.

This pull request sets a string containing a generic error message including HTTP status code as NSLocalizedDescriptionKey.
