### PR TITLE
Port FlickrKit to OS X

### DIFF
--- a/Classes/DevedUpKit/FKDUDefaultDiskCache.m
+++ b/Classes/DevedUpKit/FKDUDefaultDiskCache.m
@@ -149,7 +149,7 @@
 		}
 		
 		self.cacheSize = totalSize;
-		NSLog(@"cache size is: %d", _cacheSize);
+		NSLog(@"cache size is: %lu", (unsigned long)_cacheSize);
 	}
 	return self.cacheSize;
 }
@@ -183,11 +183,11 @@ NSInteger FKDUdateModifiedSort(id file1, id file2, void *reverse) {
 - (NSString *) trimTheCache {
     NSAssert(![NSThread currentThread].isMainThread, @"should be in background");
 	NSUInteger targetBytes = self.maxDiskCacheSize * 0.75;
-	NSLog(@"Checking disk cache size. Limit %i bytes", targetBytes);
-	NSString *size = [NSString stringWithFormat:@"%i", [self currentSizeOfCache]];
+	NSLog(@"Checking disk cache size. Limit %lu bytes", (unsigned long)targetBytes);
+	NSString *size = [NSString stringWithFormat:@"%lu", (unsigned long)[self currentSizeOfCache]];
 	
 	if ([self currentSizeOfCache] > targetBytes) {
-		NSLog(@"Time to clean the cache! size is: %@, %d", [self cacheDir], [self currentSizeOfCache]);
+		NSLog(@"Time to clean the cache! size is: %@, %lu", [self cacheDir], (unsigned long)[self currentSizeOfCache]);
 		NSError *error = nil;
 		NSArray *dirContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self cacheDir] error:&error];
 		if (!error) {
@@ -204,7 +204,7 @@ NSInteger FKDUdateModifiedSort(id file1, id file2, void *reverse) {
 				[[NSFileManager defaultManager] removeItemAtPath:[sortedDirContents lastObject] error:nil];
 				[sortedDirContents removeLastObject];
 			}
-			NSLog(@"Remaining cache size: %d, target size: %d", self.cacheSize, targetBytes);
+			NSLog(@"Remaining cache size: %lu, target size: %lu", (unsigned long)self.cacheSize, (unsigned long)targetBytes);
 		}
 	}
 	NSLog(@"Finished checking disk cache");    

--- a/Classes/FlickrKit OS X/NSImageJPEGRepresentation.h
+++ b/Classes/FlickrKit OS X/NSImageJPEGRepresentation.h
@@ -1,0 +1,12 @@
+//
+//  NSImageJPEGRepresentation.h
+//  FlickrKit OS X
+//
+//  Created by Johnnie Walker on 11/11/2013.
+//  Copyright (c) 2013 DevedUp Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NSData * NSImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality);
+

--- a/Classes/FlickrKit OS X/NSImageJPEGRepresentation.m
+++ b/Classes/FlickrKit OS X/NSImageJPEGRepresentation.m
@@ -1,0 +1,45 @@
+//
+//  NSImageJPEGRepresentation.m
+//  FlickrKit OS X
+//
+//  Created by Johnnie Walker on 11/11/2013.
+//  Copyright (c) 2013 DevedUp Ltd. All rights reserved.
+//
+
+#import "NSImageJPEGRepresentation.h"
+
+NSBitmapImageRep * bitmapImageRepresentation(NSImage *image);
+NSBitmapImageRep * bitmapImageRepresentation(NSImage *image) {
+    
+    int width = [image size].width;
+    int height = [image size].height;
+    
+    if(width < 1 || height < 1)
+        return nil;
+    
+    NSBitmapImageRep *rep = [[NSBitmapImageRep alloc]
+                             initWithBitmapDataPlanes: NULL
+                             pixelsWide: width
+                             pixelsHigh: height
+                             bitsPerSample: 8
+                             samplesPerPixel: 4
+                             hasAlpha: YES
+                             isPlanar: NO
+                             colorSpaceName: NSDeviceRGBColorSpace
+                             bytesPerRow: width * 4
+                             bitsPerPixel: 32];
+    
+    NSGraphicsContext *ctx = [NSGraphicsContext graphicsContextWithBitmapImageRep: rep];
+    [NSGraphicsContext saveGraphicsState];
+    [NSGraphicsContext setCurrentContext: ctx];
+    [image drawAtPoint: NSZeroPoint fromRect: NSZeroRect operation: NSCompositeCopy fraction: 1.0];
+    [ctx flushGraphics];
+    [NSGraphicsContext restoreGraphicsState];
+    
+    return rep;
+}
+
+NSData * NSImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality) {
+    return [bitmapImageRepresentation(image) representationUsingType:NSJPEGFileType
+                                                          properties: @{NSImageCompressionFactor: @(compressionQuality)}];
+}

--- a/Classes/FlickrKit.h
+++ b/Classes/FlickrKit.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2013 DevedUp Ltd. All rights reserved. http://www.devedup.com
 //
 
-#import <UIKit/UIKit.h>
 #import "FKDUDiskCache.h"
 #import "FKDataTypes.h"
 #import "FKFlickrNetworkOperation.h"
@@ -94,7 +93,9 @@
 #pragma mark - Photo Upload
 @interface FlickrKit (PhotoUpload)
 
+#if TARGET_OS_IPHONE
 - (FKImageUploadNetworkOperation *) uploadImage:(UIImage *)image args:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
+#endif
 
 @end
 

--- a/Classes/FlickrKit/FlickrKit.m
+++ b/Classes/FlickrKit/FlickrKit.m
@@ -452,10 +452,18 @@
 
 @implementation FlickrKit (PhotoUpload)
 
+#if TARGET_OS_IPHONE
 - (FKImageUploadNetworkOperation *) uploadImage:(UIImage *)image args:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion {
 	FKImageUploadNetworkOperation *imageUpload = [[FKImageUploadNetworkOperation alloc] initWithImage:image arguments:args completion:completion];
 	[[FKDUNetworkController sharedController] execute:imageUpload];
     return imageUpload;
 }
+#elif TARGET_OS_MAC
+- (FKImageUploadNetworkOperation *) uploadImage:(NSImage *)image args:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion {
+	FKImageUploadNetworkOperation *imageUpload = [[FKImageUploadNetworkOperation alloc] initWithImage:image arguments:args completion:completion];
+	[[FKDUNetworkController sharedController] execute:imageUpload];
+    return imageUpload;
+}
+#endif
 
 @end

--- a/Classes/Network/FKDUReachability.m
+++ b/Classes/Network/FKDUReachability.m
@@ -57,11 +57,14 @@
 					// ... and no [user] intervention is needed
 					isConnected = YES;
 				}
-			} else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN) {
+			}
+#if TARGET_OS_IPHONE
+            else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN) {
 				// ... but WWAN connections are OK if the calling application
 				//     is using the CFNetwork (CFSocketStream?) APIs.
 				isConnected = YES;
 			}
+#endif
 			
 			CFRelease(reachability);
 			return isConnected;

--- a/Classes/Network/FKImageUploadNetworkOperation.h
+++ b/Classes/Network/FKImageUploadNetworkOperation.h
@@ -7,13 +7,22 @@
 //
 
 #import "FKDUNetworkOperation.h"
-#import <UIKit/UIKit.h>
 #import "FKDataTypes.h"
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#elif TARGET_OS_MAC
+#import <Foundation/Foundation.h>
+#endif
 
 @interface FKImageUploadNetworkOperation : FKDUNetworkOperation 
 
 @property (nonatomic, assign, readonly) CGFloat uploadProgress;
 
+#if TARGET_OS_IPHONE
 - (id) initWithImage:(UIImage *)image arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
+#elif TARGET_OS_MAC
+- (id) initWithImage:(NSImage *)image arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
+#endif
 
 @end

--- a/FlickrKit OS X.xcodeproj/project.pbxproj
+++ b/FlickrKit OS X.xcodeproj/project.pbxproj
@@ -1,0 +1,2701 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5B2B54941831801B00360DAC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B2B54931831801B00360DAC /* Cocoa.framework */; };
+		5B2B549E1831801B00360DAC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5B2B549C1831801B00360DAC /* InfoPlist.strings */; };
+		5B2B54AA1831801C00360DAC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B2B54931831801B00360DAC /* Cocoa.framework */; };
+		5B2B54AD1831801C00360DAC /* FlickrKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B2B54921831801B00360DAC /* FlickrKit.framework */; };
+		5B2B54B31831801C00360DAC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5B2B54B11831801C00360DAC /* InfoPlist.strings */; };
+		5B2B54BC1831825D00360DAC /* FKDUDefaultDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D92171754DBAC00BE3FEA /* FKDUDefaultDiskCache.m */; };
+		5B2B54BD183182A800360DAC /* FKImageUploadNetworkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AD49051760DBE5004AF85C /* FKImageUploadNetworkOperation.m */; };
+		5B2B54C11831882300360DAC /* FKUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AEEF4F1756646400B61A3C /* FKUtilities.m */; };
+		5B2B54C21831882E00360DAC /* FKDataTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AD484A175CA188004AF85C /* FKDataTypes.m */; };
+		5B2B54C31831884C00360DAC /* FKDUStreamUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 55A5B667176613F900745C71 /* FKDUStreamUtil.m */; };
+		5B2B54C41831885900360DAC /* FKDUNetworkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AD48E8175F3217004AF85C /* FKDUNetworkOperation.m */; };
+		5B2B54C61831887E00360DAC /* FKURLBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91F41754AE8A00BE3FEA /* FKURLBuilder.m */; };
+		5B2B54C71831888300360DAC /* FKUploadRespone.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AD49091760E546004AF85C /* FKUploadRespone.m */; };
+		5B2B54C81831888700360DAC /* FKFlickrNetworkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91F21754AE8A00BE3FEA /* FKFlickrNetworkOperation.m */; };
+		5B2B54C9183188D200360DAC /* FKOFHMACSha1Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 55EA68AC17CAABD40017DDD1 /* FKOFHMACSha1Base64.m */; };
+		5B2B54CA183188E300360DAC /* FKDUConcurrentOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91E91754AE8A00BE3FEA /* FKDUConcurrentOperation.m */; };
+		5B2B54CB183188F300360DAC /* FKDUNetworkController.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91EB1754AE8A00BE3FEA /* FKDUNetworkController.m */; };
+		5B2B54CC1831890E00360DAC /* FlickrKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AD48E1175E7561004AF85C /* FlickrKit.m */; };
+		5B2B54CD18318A2200360DAC /* FKDUBlocks.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91E71754AE8A00BE3FEA /* FKDUBlocks.m */; };
+		5B2B54CE18318AD000360DAC /* FKDUReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AEEF56175766D500B61A3C /* FKDUReachability.m */; };
+		5B2B54CF18318B1700360DAC /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55AEEF59175766EF00B61A3C /* SystemConfiguration.framework */; };
+		5B2B54D918318EF600360DAC /* FKFlickrActivityUserComments.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D2917678A9700E84674 /* FKFlickrActivityUserComments.m */; };
+		5B2B54DA18318EF600360DAC /* FKFlickrActivityUserPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D2B17678A9700E84674 /* FKFlickrActivityUserPhotos.m */; };
+		5B2B54DB18318F0400360DAC /* FKFlickrAuthCheckToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D2E17678A9700E84674 /* FKFlickrAuthCheckToken.m */; };
+		5B2B54DC18318F0400360DAC /* FKFlickrAuthGetFrob.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3017678A9700E84674 /* FKFlickrAuthGetFrob.m */; };
+		5B2B54DD18318F0400360DAC /* FKFlickrAuthGetFullToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3217678A9700E84674 /* FKFlickrAuthGetFullToken.m */; };
+		5B2B54DE18318F0400360DAC /* FKFlickrAuthGetToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3417678A9700E84674 /* FKFlickrAuthGetToken.m */; };
+		5B2B54DF18318F0400360DAC /* FKFlickrAuthOauthCheckToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3717678A9700E84674 /* FKFlickrAuthOauthCheckToken.m */; };
+		5B2B54E018318F0400360DAC /* FKFlickrAuthOauthGetAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3917678A9700E84674 /* FKFlickrAuthOauthGetAccessToken.m */; };
+		5B2B54E118318F3400360DAC /* FKFlickrGalleriesAddPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6417678A9700E84674 /* FKFlickrGalleriesAddPhoto.m */; };
+		5B2B54E218318F3400360DAC /* FKFlickrGalleriesCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6617678A9700E84674 /* FKFlickrGalleriesCreate.m */; };
+		5B2B54E318318F3400360DAC /* FKFlickrGalleriesEditMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6817678A9700E84674 /* FKFlickrGalleriesEditMeta.m */; };
+		5B2B54E418318F3400360DAC /* FKFlickrGalleriesEditPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6A17678A9700E84674 /* FKFlickrGalleriesEditPhoto.m */; };
+		5B2B54E518318F3400360DAC /* FKFlickrGalleriesEditPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6C17678A9700E84674 /* FKFlickrGalleriesEditPhotos.m */; };
+		5B2B54E618318F3400360DAC /* FKFlickrGalleriesGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6E17678A9700E84674 /* FKFlickrGalleriesGetInfo.m */; };
+		5B2B54E718318F3400360DAC /* FKFlickrGalleriesGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7017678A9700E84674 /* FKFlickrGalleriesGetList.m */; };
+		5B2B54E818318F3400360DAC /* FKFlickrGalleriesGetListForPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7217678A9700E84674 /* FKFlickrGalleriesGetListForPhoto.m */; };
+		5B2B54E918318F3400360DAC /* FKFlickrGalleriesGetPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7417678A9700E84674 /* FKFlickrGalleriesGetPhotos.m */; };
+		5B2B54EA18318F5300360DAC /* FKFlickrCollectionsGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D4817678A9700E84674 /* FKFlickrCollectionsGetInfo.m */; };
+		5B2B54EB18318F5300360DAC /* FKFlickrCollectionsGetTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D4A17678A9700E84674 /* FKFlickrCollectionsGetTree.m */; };
+		5B2B54EC18318F5300360DAC /* FKFlickrCommonsGetInstitutions.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D4D17678A9700E84674 /* FKFlickrCommonsGetInstitutions.m */; };
+		5B2B54ED18318F5300360DAC /* FKFlickrContactsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5017678A9700E84674 /* FKFlickrContactsGetList.m */; };
+		5B2B54EE18318F5300360DAC /* FKFlickrContactsGetListRecentlyUploaded.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5217678A9700E84674 /* FKFlickrContactsGetListRecentlyUploaded.m */; };
+		5B2B54EF18318F5300360DAC /* FKFlickrContactsGetPublicList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5417678A9700E84674 /* FKFlickrContactsGetPublicList.m */; };
+		5B2B54F018318F5300360DAC /* FKFlickrContactsGetTaggingSuggestions.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5617678A9700E84674 /* FKFlickrContactsGetTaggingSuggestions.m */; };
+		5B2B54F118318F5300360DAC /* FKFlickrFavoritesAdd.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5917678A9700E84674 /* FKFlickrFavoritesAdd.m */; };
+		5B2B54F218318F5300360DAC /* FKFlickrFavoritesGetContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5B17678A9700E84674 /* FKFlickrFavoritesGetContext.m */; };
+		5B2B54F318318F5300360DAC /* FKFlickrFavoritesGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5D17678A9700E84674 /* FKFlickrFavoritesGetList.m */; };
+		5B2B54F418318F5300360DAC /* FKFlickrFavoritesGetPublicList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D5F17678A9700E84674 /* FKFlickrFavoritesGetPublicList.m */; };
+		5B2B54F518318F5300360DAC /* FKFlickrFavoritesRemove.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D6117678A9700E84674 /* FKFlickrFavoritesRemove.m */; };
+		5B2B54F618318F6B00360DAC /* FKFlickrBlogsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3C17678A9700E84674 /* FKFlickrBlogsGetList.m */; };
+		5B2B54F718318F6B00360DAC /* FKFlickrBlogsGetServices.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D3E17678A9700E84674 /* FKFlickrBlogsGetServices.m */; };
+		5B2B54F818318F6B00360DAC /* FKFlickrBlogsPostPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D4017678A9700E84674 /* FKFlickrBlogsPostPhoto.m */; };
+		5B2B54F918318F6B00360DAC /* FKFlickrCamerasGetBrandModels.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D4317678A9700E84674 /* FKFlickrCamerasGetBrandModels.m */; };
+		5B2B54FA18318F6B00360DAC /* FKFlickrCamerasGetBrands.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D4517678A9700E84674 /* FKFlickrCamerasGetBrands.m */; };
+		5B2B54FB18318F9700360DAC /* FKFlickrGroupsDiscussRepliesAdd.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7917678A9700E84674 /* FKFlickrGroupsDiscussRepliesAdd.m */; };
+		5B2B54FC18318F9700360DAC /* FKFlickrGroupsDiscussRepliesDelete.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7B17678A9700E84674 /* FKFlickrGroupsDiscussRepliesDelete.m */; };
+		5B2B54FD18318F9700360DAC /* FKFlickrGroupsDiscussRepliesEdit.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7D17678A9700E84674 /* FKFlickrGroupsDiscussRepliesEdit.m */; };
+		5B2B54FE18318F9700360DAC /* FKFlickrGroupsDiscussRepliesGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D7F17678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetInfo.m */; };
+		5B2B54FF18318F9700360DAC /* FKFlickrGroupsDiscussRepliesGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8117678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetList.m */; };
+		5B2B550018318F9700360DAC /* FKFlickrGroupsDiscussTopicsAdd.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8417678A9700E84674 /* FKFlickrGroupsDiscussTopicsAdd.m */; };
+		5B2B550118318F9700360DAC /* FKFlickrGroupsDiscussTopicsGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8617678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetInfo.m */; };
+		5B2B550218318F9700360DAC /* FKFlickrGroupsDiscussTopicsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8817678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetList.m */; };
+		5B2B550318318F9700360DAC /* FKFlickrGroupsBrowse.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8A17678A9700E84674 /* FKFlickrGroupsBrowse.m */; };
+		5B2B550418318F9700360DAC /* FKFlickrGroupsGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8C17678A9700E84674 /* FKFlickrGroupsGetInfo.m */; };
+		5B2B550518318F9700360DAC /* FKFlickrGroupsJoin.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D8E17678A9700E84674 /* FKFlickrGroupsJoin.m */; };
+		5B2B550618318F9700360DAC /* FKFlickrGroupsJoinRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9017678A9700E84674 /* FKFlickrGroupsJoinRequest.m */; };
+		5B2B550718318F9700360DAC /* FKFlickrGroupsLeave.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9217678A9700E84674 /* FKFlickrGroupsLeave.m */; };
+		5B2B550818318F9700360DAC /* FKFlickrGroupsSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9417678A9700E84674 /* FKFlickrGroupsSearch.m */; };
+		5B2B550918318FC200360DAC /* FKFlickrGroupsMembersGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9717678A9700E84674 /* FKFlickrGroupsMembersGetList.m */; };
+		5B2B550A18318FC200360DAC /* FKFlickrGroupsPoolsAdd.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9A17678A9700E84674 /* FKFlickrGroupsPoolsAdd.m */; };
+		5B2B550B18318FC200360DAC /* FKFlickrGroupsPoolsGetContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9C17678A9700E84674 /* FKFlickrGroupsPoolsGetContext.m */; };
+		5B2B550C18318FC200360DAC /* FKFlickrGroupsPoolsGetGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2D9E17678A9700E84674 /* FKFlickrGroupsPoolsGetGroups.m */; };
+		5B2B550D18318FC200360DAC /* FKFlickrGroupsPoolsGetPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DA017678A9700E84674 /* FKFlickrGroupsPoolsGetPhotos.m */; };
+		5B2B550E18318FC200360DAC /* FKFlickrGroupsPoolsRemove.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DA217678A9700E84674 /* FKFlickrGroupsPoolsRemove.m */; };
+		5B2B550F18318FC200360DAC /* FKFlickrInterestingnessGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DA517678A9700E84674 /* FKFlickrInterestingnessGetList.m */; };
+		5B2B551018318FC200360DAC /* FKFlickrMachinetagsGetNamespaces.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DA817678A9700E84674 /* FKFlickrMachinetagsGetNamespaces.m */; };
+		5B2B551118318FC200360DAC /* FKFlickrMachinetagsGetPairs.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DAA17678A9700E84674 /* FKFlickrMachinetagsGetPairs.m */; };
+		5B2B551218318FC200360DAC /* FKFlickrMachinetagsGetPredicates.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DAC17678A9700E84674 /* FKFlickrMachinetagsGetPredicates.m */; };
+		5B2B551318318FC200360DAC /* FKFlickrMachinetagsGetRecentValues.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DAE17678A9700E84674 /* FKFlickrMachinetagsGetRecentValues.m */; };
+		5B2B551418318FC200360DAC /* FKFlickrMachinetagsGetValues.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DB017678A9700E84674 /* FKFlickrMachinetagsGetValues.m */; };
+		5B2B551518318FC200360DAC /* FKFlickrPandaGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DB317678A9700E84674 /* FKFlickrPandaGetList.m */; };
+		5B2B551618318FC200360DAC /* FKFlickrPandaGetPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DB517678A9700E84674 /* FKFlickrPandaGetPhotos.m */; };
+		5B2B551718318FC200360DAC /* FKFlickrPeopleFindByEmail.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DB817678A9700E84674 /* FKFlickrPeopleFindByEmail.m */; };
+		5B2B551818318FC200360DAC /* FKFlickrPeopleFindByUsername.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DBA17678A9700E84674 /* FKFlickrPeopleFindByUsername.m */; };
+		5B2B551918318FC200360DAC /* FKFlickrPeopleGetGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DBC17678A9700E84674 /* FKFlickrPeopleGetGroups.m */; };
+		5B2B551A18318FC200360DAC /* FKFlickrPeopleGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DBE17678A9700E84674 /* FKFlickrPeopleGetInfo.m */; };
+		5B2B551B18318FC200360DAC /* FKFlickrPeopleGetLimits.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DC017678A9700E84674 /* FKFlickrPeopleGetLimits.m */; };
+		5B2B551C18318FC200360DAC /* FKFlickrPeopleGetPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DC217678A9700E84674 /* FKFlickrPeopleGetPhotos.m */; };
+		5B2B551D18318FC200360DAC /* FKFlickrPeopleGetPhotosOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DC417678A9700E84674 /* FKFlickrPeopleGetPhotosOf.m */; };
+		5B2B551E18318FC200360DAC /* FKFlickrPeopleGetPublicGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DC617678A9700E84674 /* FKFlickrPeopleGetPublicGroups.m */; };
+		5B2B551F18318FC200360DAC /* FKFlickrPeopleGetPublicPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DC817678A9700E84674 /* FKFlickrPeopleGetPublicPhotos.m */; };
+		5B2B552018318FC200360DAC /* FKFlickrPeopleGetUploadStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DCA17678A9700E84674 /* FKFlickrPeopleGetUploadStatus.m */; };
+		5B2B552118318FF300360DAC /* FKFlickrPhotosCommentsAddComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DCE17678A9700E84674 /* FKFlickrPhotosCommentsAddComment.m */; };
+		5B2B552218318FF300360DAC /* FKFlickrPhotosCommentsDeleteComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DD017678A9700E84674 /* FKFlickrPhotosCommentsDeleteComment.m */; };
+		5B2B552318318FF300360DAC /* FKFlickrPhotosCommentsEditComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DD217678A9700E84674 /* FKFlickrPhotosCommentsEditComment.m */; };
+		5B2B552418318FF300360DAC /* FKFlickrPhotosCommentsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DD417678A9700E84674 /* FKFlickrPhotosCommentsGetList.m */; };
+		5B2B552518318FF300360DAC /* FKFlickrPhotosCommentsGetRecentForContacts.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DD617678A9700E84674 /* FKFlickrPhotosCommentsGetRecentForContacts.m */; };
+		5B2B552618318FF300360DAC /* FKFlickrPhotosAddTags.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DD817678A9700E84674 /* FKFlickrPhotosAddTags.m */; };
+		5B2B552718318FF300360DAC /* FKFlickrPhotosDelete.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DDA17678A9700E84674 /* FKFlickrPhotosDelete.m */; };
+		5B2B552818318FF300360DAC /* FKFlickrPhotosGetAllContexts.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DDC17678A9700E84674 /* FKFlickrPhotosGetAllContexts.m */; };
+		5B2B552918318FF300360DAC /* FKFlickrPhotosGetContactsPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DDE17678A9700E84674 /* FKFlickrPhotosGetContactsPhotos.m */; };
+		5B2B552A18318FF300360DAC /* FKFlickrPhotosGetContactsPublicPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DE017678A9700E84674 /* FKFlickrPhotosGetContactsPublicPhotos.m */; };
+		5B2B552B18318FF300360DAC /* FKFlickrPhotosGetContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DE217678A9700E84674 /* FKFlickrPhotosGetContext.m */; };
+		5B2B552C18318FF300360DAC /* FKFlickrPhotosGetCounts.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DE417678A9700E84674 /* FKFlickrPhotosGetCounts.m */; };
+		5B2B552D18318FF300360DAC /* FKFlickrPhotosGetExif.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DE617678A9700E84674 /* FKFlickrPhotosGetExif.m */; };
+		5B2B552E18318FF300360DAC /* FKFlickrPhotosGetFavorites.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DE817678A9700E84674 /* FKFlickrPhotosGetFavorites.m */; };
+		5B2B552F18318FF300360DAC /* FKFlickrPhotosGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DEA17678A9700E84674 /* FKFlickrPhotosGetInfo.m */; };
+		5B2B553018318FF300360DAC /* FKFlickrPhotosGetNotInSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DEC17678A9700E84674 /* FKFlickrPhotosGetNotInSet.m */; };
+		5B2B553118318FF300360DAC /* FKFlickrPhotosGetPerms.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DEE17678A9700E84674 /* FKFlickrPhotosGetPerms.m */; };
+		5B2B553218318FF300360DAC /* FKFlickrPhotosGetRecent.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DF017678A9700E84674 /* FKFlickrPhotosGetRecent.m */; };
+		5B2B553318318FF300360DAC /* FKFlickrPhotosGetSizes.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DF217678A9700E84674 /* FKFlickrPhotosGetSizes.m */; };
+		5B2B553418318FF300360DAC /* FKFlickrPhotosGetUntagged.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DF417678A9700E84674 /* FKFlickrPhotosGetUntagged.m */; };
+		5B2B553518318FF300360DAC /* FKFlickrPhotosGetWithGeoData.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DF617678A9700E84674 /* FKFlickrPhotosGetWithGeoData.m */; };
+		5B2B553618318FF300360DAC /* FKFlickrPhotosGetWithoutGeoData.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DF817678A9700E84674 /* FKFlickrPhotosGetWithoutGeoData.m */; };
+		5B2B553718318FF300360DAC /* FKFlickrPhotosRecentlyUpdated.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DFA17678A9700E84674 /* FKFlickrPhotosRecentlyUpdated.m */; };
+		5B2B553818318FF300360DAC /* FKFlickrPhotosRemoveTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DFC17678A9700E84674 /* FKFlickrPhotosRemoveTag.m */; };
+		5B2B553918318FF300360DAC /* FKFlickrPhotosSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2DFE17678A9700E84674 /* FKFlickrPhotosSearch.m */; };
+		5B2B553A18318FF300360DAC /* FKFlickrPhotosSetContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0017678A9700E84674 /* FKFlickrPhotosSetContentType.m */; };
+		5B2B553B18318FF300360DAC /* FKFlickrPhotosSetDates.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0217678A9700E84674 /* FKFlickrPhotosSetDates.m */; };
+		5B2B553C18318FF300360DAC /* FKFlickrPhotosSetMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0417678A9700E84674 /* FKFlickrPhotosSetMeta.m */; };
+		5B2B553D18318FF300360DAC /* FKFlickrPhotosSetPerms.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0617678A9700E84674 /* FKFlickrPhotosSetPerms.m */; };
+		5B2B553E18318FF300360DAC /* FKFlickrPhotosSetSafetyLevel.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0817678A9700E84674 /* FKFlickrPhotosSetSafetyLevel.m */; };
+		5B2B553F18318FF300360DAC /* FKFlickrPhotosSetTags.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0A17678A9700E84674 /* FKFlickrPhotosSetTags.m */; };
+		5B2B55401831900C00360DAC /* FKFlickrPhotosGeoBatchCorrectLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E0E17678A9700E84674 /* FKFlickrPhotosGeoBatchCorrectLocation.m */; };
+		5B2B55411831900C00360DAC /* FKFlickrPhotosGeoCorrectLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1017678A9700E84674 /* FKFlickrPhotosGeoCorrectLocation.m */; };
+		5B2B55421831900C00360DAC /* FKFlickrPhotosGeoGetLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1217678A9700E84674 /* FKFlickrPhotosGeoGetLocation.m */; };
+		5B2B55431831900C00360DAC /* FKFlickrPhotosGeoGetPerms.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1417678A9700E84674 /* FKFlickrPhotosGeoGetPerms.m */; };
+		5B2B55441831900C00360DAC /* FKFlickrPhotosGeoPhotosForLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1617678A9700E84674 /* FKFlickrPhotosGeoPhotosForLocation.m */; };
+		5B2B55451831900C00360DAC /* FKFlickrPhotosGeoRemoveLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1817678A9700E84674 /* FKFlickrPhotosGeoRemoveLocation.m */; };
+		5B2B55461831900C00360DAC /* FKFlickrPhotosGeoSetContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1A17678A9700E84674 /* FKFlickrPhotosGeoSetContext.m */; };
+		5B2B55471831900C00360DAC /* FKFlickrPhotosGeoSetLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1C17678A9700E84674 /* FKFlickrPhotosGeoSetLocation.m */; };
+		5B2B55481831900C00360DAC /* FKFlickrPhotosGeoSetPerms.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E1E17678A9700E84674 /* FKFlickrPhotosGeoSetPerms.m */; };
+		5B2B55491831901C00360DAC /* FKFlickrPhotosLicensesGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2117678A9700E84674 /* FKFlickrPhotosLicensesGetInfo.m */; };
+		5B2B554A1831901C00360DAC /* FKFlickrPhotosLicensesSetLicense.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2317678A9700E84674 /* FKFlickrPhotosLicensesSetLicense.m */; };
+		5B2B554B1831904B00360DAC /* FKFlickrPhotosNotesAdd.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2617678A9700E84674 /* FKFlickrPhotosNotesAdd.m */; };
+		5B2B554C1831904B00360DAC /* FKFlickrPhotosNotesDelete.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2817678A9700E84674 /* FKFlickrPhotosNotesDelete.m */; };
+		5B2B554D1831904B00360DAC /* FKFlickrPhotosNotesEdit.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2A17678A9700E84674 /* FKFlickrPhotosNotesEdit.m */; };
+		5B2B554E1831904B00360DAC /* FKFlickrPhotosPeopleAdd.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2D17678A9700E84674 /* FKFlickrPhotosPeopleAdd.m */; };
+		5B2B554F1831904B00360DAC /* FKFlickrPhotosPeopleDelete.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E2F17678A9700E84674 /* FKFlickrPhotosPeopleDelete.m */; };
+		5B2B55501831904B00360DAC /* FKFlickrPhotosPeopleDeleteCoords.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3117678A9700E84674 /* FKFlickrPhotosPeopleDeleteCoords.m */; };
+		5B2B55511831904B00360DAC /* FKFlickrPhotosPeopleEditCoords.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3317678A9700E84674 /* FKFlickrPhotosPeopleEditCoords.m */; };
+		5B2B55521831904B00360DAC /* FKFlickrPhotosPeopleGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3517678A9700E84674 /* FKFlickrPhotosPeopleGetList.m */; };
+		5B2B55531831906300360DAC /* FKFlickrPhotosSuggestionsApproveSuggestion.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3817678A9700E84674 /* FKFlickrPhotosSuggestionsApproveSuggestion.m */; };
+		5B2B55541831906300360DAC /* FKFlickrPhotosSuggestionsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3A17678A9700E84674 /* FKFlickrPhotosSuggestionsGetList.m */; };
+		5B2B55551831906300360DAC /* FKFlickrPhotosSuggestionsRejectSuggestion.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3C17678A9700E84674 /* FKFlickrPhotosSuggestionsRejectSuggestion.m */; };
+		5B2B55561831906300360DAC /* FKFlickrPhotosSuggestionsRemoveSuggestion.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E3E17678A9700E84674 /* FKFlickrPhotosSuggestionsRemoveSuggestion.m */; };
+		5B2B55571831906300360DAC /* FKFlickrPhotosSuggestionsSuggestLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E4017678A9700E84674 /* FKFlickrPhotosSuggestionsSuggestLocation.m */; };
+		5B2B55581831906300360DAC /* FKFlickrPhotosTransformRotate.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E4317678A9700E84674 /* FKFlickrPhotosTransformRotate.m */; };
+		5B2B55591831906300360DAC /* FKFlickrPhotosUploadCheckTickets.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E4617678A9700E84674 /* FKFlickrPhotosUploadCheckTickets.m */; };
+		5B2B555A1831908200360DAC /* FKFlickrPhotosetsCommentsAddComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E4A17678A9700E84674 /* FKFlickrPhotosetsCommentsAddComment.m */; };
+		5B2B555B1831908200360DAC /* FKFlickrPhotosetsCommentsDeleteComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E4C17678A9700E84674 /* FKFlickrPhotosetsCommentsDeleteComment.m */; };
+		5B2B555C1831908200360DAC /* FKFlickrPhotosetsCommentsEditComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E4E17678A9700E84674 /* FKFlickrPhotosetsCommentsEditComment.m */; };
+		5B2B555D1831908200360DAC /* FKFlickrPhotosetsCommentsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5017678A9700E84674 /* FKFlickrPhotosetsCommentsGetList.m */; };
+		5B2B555E1831908200360DAC /* FKFlickrPhotosetsAddPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5217678A9700E84674 /* FKFlickrPhotosetsAddPhoto.m */; };
+		5B2B555F1831908200360DAC /* FKFlickrPhotosetsCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5417678A9700E84674 /* FKFlickrPhotosetsCreate.m */; };
+		5B2B55601831908200360DAC /* FKFlickrPhotosetsDelete.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5617678A9700E84674 /* FKFlickrPhotosetsDelete.m */; };
+		5B2B55611831908200360DAC /* FKFlickrPhotosetsEditMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5817678A9700E84674 /* FKFlickrPhotosetsEditMeta.m */; };
+		5B2B55621831908200360DAC /* FKFlickrPhotosetsEditPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5A17678A9700E84674 /* FKFlickrPhotosetsEditPhotos.m */; };
+		5B2B55631831908200360DAC /* FKFlickrPhotosetsGetContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5C17678A9700E84674 /* FKFlickrPhotosetsGetContext.m */; };
+		5B2B55641831908200360DAC /* FKFlickrPhotosetsGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E5E17678A9700E84674 /* FKFlickrPhotosetsGetInfo.m */; };
+		5B2B55651831908200360DAC /* FKFlickrPhotosetsGetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6017678A9700E84674 /* FKFlickrPhotosetsGetList.m */; };
+		5B2B55661831908200360DAC /* FKFlickrPhotosetsGetPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6217678A9700E84674 /* FKFlickrPhotosetsGetPhotos.m */; };
+		5B2B55671831908200360DAC /* FKFlickrPhotosetsOrderSets.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6417678A9700E84674 /* FKFlickrPhotosetsOrderSets.m */; };
+		5B2B55681831908200360DAC /* FKFlickrPhotosetsRemovePhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6617678A9700E84674 /* FKFlickrPhotosetsRemovePhoto.m */; };
+		5B2B55691831908200360DAC /* FKFlickrPhotosetsRemovePhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6817678A9700E84674 /* FKFlickrPhotosetsRemovePhotos.m */; };
+		5B2B556A1831908200360DAC /* FKFlickrPhotosetsReorderPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6A17678A9700E84674 /* FKFlickrPhotosetsReorderPhotos.m */; };
+		5B2B556B1831908200360DAC /* FKFlickrPhotosetsSetPrimaryPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6C17678A9700E84674 /* FKFlickrPhotosetsSetPrimaryPhoto.m */; };
+		5B2B556C183190B500360DAC /* FKFlickrPlacesFind.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E6F17678A9700E84674 /* FKFlickrPlacesFind.m */; };
+		5B2B556D183190B500360DAC /* FKFlickrPlacesFindByLatLon.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7117678A9700E84674 /* FKFlickrPlacesFindByLatLon.m */; };
+		5B2B556E183190B500360DAC /* FKFlickrPlacesGetChildrenWithPhotosPublic.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7317678A9700E84674 /* FKFlickrPlacesGetChildrenWithPhotosPublic.m */; };
+		5B2B556F183190B500360DAC /* FKFlickrPlacesGetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7517678A9700E84674 /* FKFlickrPlacesGetInfo.m */; };
+		5B2B5570183190B500360DAC /* FKFlickrPlacesGetInfoByUrl.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7717678A9700E84674 /* FKFlickrPlacesGetInfoByUrl.m */; };
+		5B2B5571183190B500360DAC /* FKFlickrPlacesGetPlaceTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7917678A9700E84674 /* FKFlickrPlacesGetPlaceTypes.m */; };
+		5B2B5572183190B500360DAC /* FKFlickrPlacesGetShapeHistory.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7B17678A9700E84674 /* FKFlickrPlacesGetShapeHistory.m */; };
+		5B2B5573183190B500360DAC /* FKFlickrPlacesGetTopPlacesList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7D17678A9700E84674 /* FKFlickrPlacesGetTopPlacesList.m */; };
+		5B2B5574183190B500360DAC /* FKFlickrPlacesPlacesForBoundingBox.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E7F17678A9700E84674 /* FKFlickrPlacesPlacesForBoundingBox.m */; };
+		5B2B5575183190B500360DAC /* FKFlickrPlacesPlacesForContacts.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8117678A9700E84674 /* FKFlickrPlacesPlacesForContacts.m */; };
+		5B2B5576183190B500360DAC /* FKFlickrPlacesPlacesForTags.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8317678A9700E84674 /* FKFlickrPlacesPlacesForTags.m */; };
+		5B2B5577183190B500360DAC /* FKFlickrPlacesPlacesForUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8517678A9800E84674 /* FKFlickrPlacesPlacesForUser.m */; };
+		5B2B5578183190B500360DAC /* FKFlickrPlacesResolvePlaceId.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8717678A9800E84674 /* FKFlickrPlacesResolvePlaceId.m */; };
+		5B2B5579183190B500360DAC /* FKFlickrPlacesResolvePlaceURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8917678A9800E84674 /* FKFlickrPlacesResolvePlaceURL.m */; };
+		5B2B557A183190B500360DAC /* FKFlickrPlacesTagsForPlace.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8B17678A9800E84674 /* FKFlickrPlacesTagsForPlace.m */; };
+		5B2B557B183190B500360DAC /* FKFlickrPrefsGetContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E8E17678A9800E84674 /* FKFlickrPrefsGetContentType.m */; };
+		5B2B557C183190B500360DAC /* FKFlickrPrefsGetGeoPerms.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9017678A9800E84674 /* FKFlickrPrefsGetGeoPerms.m */; };
+		5B2B557D183190B500360DAC /* FKFlickrPrefsGetHidden.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9217678A9800E84674 /* FKFlickrPrefsGetHidden.m */; };
+		5B2B557E183190B500360DAC /* FKFlickrPrefsGetPrivacy.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9417678A9800E84674 /* FKFlickrPrefsGetPrivacy.m */; };
+		5B2B557F183190B500360DAC /* FKFlickrPrefsGetSafetyLevel.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9617678A9800E84674 /* FKFlickrPrefsGetSafetyLevel.m */; };
+		5B2B5580183190B500360DAC /* FKFlickrPushGetSubscriptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9917678A9800E84674 /* FKFlickrPushGetSubscriptions.m */; };
+		5B2B5581183190B500360DAC /* FKFlickrPushGetTopics.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9B17678A9800E84674 /* FKFlickrPushGetTopics.m */; };
+		5B2B5582183190B500360DAC /* FKFlickrPushSubscribe.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9D17678A9800E84674 /* FKFlickrPushSubscribe.m */; };
+		5B2B5583183190B500360DAC /* FKFlickrPushUnsubscribe.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2E9F17678A9800E84674 /* FKFlickrPushUnsubscribe.m */; };
+		5B2B5584183190B500360DAC /* FKFlickrReflectionGetMethodInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EA217678A9800E84674 /* FKFlickrReflectionGetMethodInfo.m */; };
+		5B2B5585183190B500360DAC /* FKFlickrReflectionGetMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EA417678A9800E84674 /* FKFlickrReflectionGetMethods.m */; };
+		5B2B5586183190DA00360DAC /* FKFlickrStatsGetCollectionDomains.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EA717678A9800E84674 /* FKFlickrStatsGetCollectionDomains.m */; };
+		5B2B5587183190DA00360DAC /* FKFlickrStatsGetCollectionReferrers.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EA917678A9800E84674 /* FKFlickrStatsGetCollectionReferrers.m */; };
+		5B2B5588183190DA00360DAC /* FKFlickrStatsGetCollectionStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EAB17678A9800E84674 /* FKFlickrStatsGetCollectionStats.m */; };
+		5B2B5589183190DA00360DAC /* FKFlickrStatsGetCSVFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EAD17678A9800E84674 /* FKFlickrStatsGetCSVFiles.m */; };
+		5B2B558A183190DA00360DAC /* FKFlickrStatsGetPhotoDomains.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EAF17678A9800E84674 /* FKFlickrStatsGetPhotoDomains.m */; };
+		5B2B558B183190DA00360DAC /* FKFlickrStatsGetPhotoReferrers.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EB117678A9800E84674 /* FKFlickrStatsGetPhotoReferrers.m */; };
+		5B2B558C183190DA00360DAC /* FKFlickrStatsGetPhotosetDomains.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EB317678A9800E84674 /* FKFlickrStatsGetPhotosetDomains.m */; };
+		5B2B558D183190DA00360DAC /* FKFlickrStatsGetPhotosetReferrers.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EB517678A9800E84674 /* FKFlickrStatsGetPhotosetReferrers.m */; };
+		5B2B558E183190DA00360DAC /* FKFlickrStatsGetPhotosetStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EB717678A9800E84674 /* FKFlickrStatsGetPhotosetStats.m */; };
+		5B2B558F183190DA00360DAC /* FKFlickrStatsGetPhotoStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EB917678A9800E84674 /* FKFlickrStatsGetPhotoStats.m */; };
+		5B2B5590183190DA00360DAC /* FKFlickrStatsGetPhotostreamDomains.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EBB17678A9800E84674 /* FKFlickrStatsGetPhotostreamDomains.m */; };
+		5B2B5591183190DA00360DAC /* FKFlickrStatsGetPhotostreamReferrers.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EBD17678A9800E84674 /* FKFlickrStatsGetPhotostreamReferrers.m */; };
+		5B2B5592183190DA00360DAC /* FKFlickrStatsGetPhotostreamStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EBF17678A9800E84674 /* FKFlickrStatsGetPhotostreamStats.m */; };
+		5B2B5593183190DA00360DAC /* FKFlickrStatsGetPopularPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EC117678A9800E84674 /* FKFlickrStatsGetPopularPhotos.m */; };
+		5B2B5594183190DA00360DAC /* FKFlickrStatsGetTotalViews.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EC317678A9800E84674 /* FKFlickrStatsGetTotalViews.m */; };
+		5B2B5595183190EC00360DAC /* FKFlickrTagsGetClusterPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EC617678A9800E84674 /* FKFlickrTagsGetClusterPhotos.m */; };
+		5B2B5596183190EC00360DAC /* FKFlickrTagsGetClusters.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EC817678A9800E84674 /* FKFlickrTagsGetClusters.m */; };
+		5B2B5597183190EC00360DAC /* FKFlickrTagsGetHotList.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ECA17678A9800E84674 /* FKFlickrTagsGetHotList.m */; };
+		5B2B5598183190EC00360DAC /* FKFlickrTagsGetListPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ECC17678A9800E84674 /* FKFlickrTagsGetListPhoto.m */; };
+		5B2B5599183190EC00360DAC /* FKFlickrTagsGetListUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ECE17678A9800E84674 /* FKFlickrTagsGetListUser.m */; };
+		5B2B559A183190EC00360DAC /* FKFlickrTagsGetListUserPopular.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ED017678A9800E84674 /* FKFlickrTagsGetListUserPopular.m */; };
+		5B2B559B183190EC00360DAC /* FKFlickrTagsGetListUserRaw.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ED217678A9800E84674 /* FKFlickrTagsGetListUserRaw.m */; };
+		5B2B559C183190EC00360DAC /* FKFlickrTagsGetMostFrequentlyUsed.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ED417678A9800E84674 /* FKFlickrTagsGetMostFrequentlyUsed.m */; };
+		5B2B559D183190EC00360DAC /* FKFlickrTagsGetRelated.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ED617678A9800E84674 /* FKFlickrTagsGetRelated.m */; };
+		5B2B559E183190FA00360DAC /* FKFlickrTestEcho.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2ED917678A9800E84674 /* FKFlickrTestEcho.m */; };
+		5B2B559F183190FA00360DAC /* FKFlickrTestLogin.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EDB17678A9800E84674 /* FKFlickrTestLogin.m */; };
+		5B2B55A0183190FA00360DAC /* FKFlickrTestNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EDD17678A9800E84674 /* FKFlickrTestNull.m */; };
+		5B2B55A11831910500360DAC /* FKFlickrUrlsGetGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EE017678A9800E84674 /* FKFlickrUrlsGetGroup.m */; };
+		5B2B55A21831910500360DAC /* FKFlickrUrlsGetUserPhotos.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EE217678A9800E84674 /* FKFlickrUrlsGetUserPhotos.m */; };
+		5B2B55A31831910500360DAC /* FKFlickrUrlsGetUserProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EE417678A9800E84674 /* FKFlickrUrlsGetUserProfile.m */; };
+		5B2B55A41831910500360DAC /* FKFlickrUrlsLookupGallery.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EE617678A9800E84674 /* FKFlickrUrlsLookupGallery.m */; };
+		5B2B55A51831910500360DAC /* FKFlickrUrlsLookupGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EE817678A9800E84674 /* FKFlickrUrlsLookupGroup.m */; };
+		5B2B55A61831910500360DAC /* FKFlickrUrlsLookupUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 555F2EEA17678A9800E84674 /* FKFlickrUrlsLookupUser.m */; };
+		5B2B55A71831914700360DAC /* FKFlickrActivityUserComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D2817678A9700E84674 /* FKFlickrActivityUserComments.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55A81831914700360DAC /* FKFlickrActivityUserPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D2A17678A9700E84674 /* FKFlickrActivityUserPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55A91831915300360DAC /* FKFlickrAuthCheckToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D2D17678A9700E84674 /* FKFlickrAuthCheckToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55AA1831915300360DAC /* FKFlickrAuthGetFrob.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D2F17678A9700E84674 /* FKFlickrAuthGetFrob.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55AB1831915300360DAC /* FKFlickrAuthGetFullToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3117678A9700E84674 /* FKFlickrAuthGetFullToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55AC1831915300360DAC /* FKFlickrAuthGetToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3317678A9700E84674 /* FKFlickrAuthGetToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55AD1831918700360DAC /* FKFlickrAuthOauthCheckToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3617678A9700E84674 /* FKFlickrAuthOauthCheckToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55AE1831918700360DAC /* FKFlickrAuthOauthGetAccessToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3817678A9700E84674 /* FKFlickrAuthOauthGetAccessToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55AF1831918700360DAC /* FKFlickrBlogsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3B17678A9700E84674 /* FKFlickrBlogsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B01831918700360DAC /* FKFlickrBlogsGetServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3D17678A9700E84674 /* FKFlickrBlogsGetServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B11831918700360DAC /* FKFlickrBlogsPostPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D3F17678A9700E84674 /* FKFlickrBlogsPostPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B21831918700360DAC /* FKFlickrCamerasGetBrandModels.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D4217678A9700E84674 /* FKFlickrCamerasGetBrandModels.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B31831918700360DAC /* FKFlickrCamerasGetBrands.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D4417678A9700E84674 /* FKFlickrCamerasGetBrands.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B41831918700360DAC /* FKFlickrCollectionsGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D4717678A9700E84674 /* FKFlickrCollectionsGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B51831918700360DAC /* FKFlickrCollectionsGetTree.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D4917678A9700E84674 /* FKFlickrCollectionsGetTree.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B61831918700360DAC /* FKFlickrCommonsGetInstitutions.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D4C17678A9700E84674 /* FKFlickrCommonsGetInstitutions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B71831918700360DAC /* FKFlickrContactsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D4F17678A9700E84674 /* FKFlickrContactsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B81831918700360DAC /* FKFlickrContactsGetListRecentlyUploaded.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5117678A9700E84674 /* FKFlickrContactsGetListRecentlyUploaded.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55B91831918700360DAC /* FKFlickrContactsGetPublicList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5317678A9700E84674 /* FKFlickrContactsGetPublicList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55BA1831918700360DAC /* FKFlickrContactsGetTaggingSuggestions.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5517678A9700E84674 /* FKFlickrContactsGetTaggingSuggestions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55BB1831918700360DAC /* FKFlickrFavoritesAdd.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5817678A9700E84674 /* FKFlickrFavoritesAdd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55BC1831918700360DAC /* FKFlickrFavoritesGetContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5A17678A9700E84674 /* FKFlickrFavoritesGetContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55BD1831918700360DAC /* FKFlickrFavoritesGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5C17678A9700E84674 /* FKFlickrFavoritesGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55BE1831918700360DAC /* FKFlickrFavoritesGetPublicList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D5E17678A9700E84674 /* FKFlickrFavoritesGetPublicList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55BF1831918700360DAC /* FKFlickrFavoritesRemove.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6017678A9700E84674 /* FKFlickrFavoritesRemove.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C01831919500360DAC /* FKFlickrGalleriesAddPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6317678A9700E84674 /* FKFlickrGalleriesAddPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C11831919500360DAC /* FKFlickrGalleriesCreate.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6517678A9700E84674 /* FKFlickrGalleriesCreate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C21831919500360DAC /* FKFlickrGalleriesEditMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6717678A9700E84674 /* FKFlickrGalleriesEditMeta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C31831919500360DAC /* FKFlickrGalleriesEditPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6917678A9700E84674 /* FKFlickrGalleriesEditPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C41831919500360DAC /* FKFlickrGalleriesEditPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6B17678A9700E84674 /* FKFlickrGalleriesEditPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C51831919500360DAC /* FKFlickrGalleriesGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6D17678A9700E84674 /* FKFlickrGalleriesGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C61831919500360DAC /* FKFlickrGalleriesGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D6F17678A9700E84674 /* FKFlickrGalleriesGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C71831919500360DAC /* FKFlickrGalleriesGetListForPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D7117678A9700E84674 /* FKFlickrGalleriesGetListForPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C81831919500360DAC /* FKFlickrGalleriesGetPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D7317678A9700E84674 /* FKFlickrGalleriesGetPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55C9183191C500360DAC /* FKFlickrGroupsDiscussRepliesAdd.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D7817678A9700E84674 /* FKFlickrGroupsDiscussRepliesAdd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55CA183191C500360DAC /* FKFlickrGroupsDiscussRepliesDelete.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D7A17678A9700E84674 /* FKFlickrGroupsDiscussRepliesDelete.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55CB183191C500360DAC /* FKFlickrGroupsDiscussRepliesEdit.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D7C17678A9700E84674 /* FKFlickrGroupsDiscussRepliesEdit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55CC183191C500360DAC /* FKFlickrGroupsDiscussRepliesGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D7E17678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55CD183191C500360DAC /* FKFlickrGroupsDiscussRepliesGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8017678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55CE183191C500360DAC /* FKFlickrGroupsDiscussTopicsAdd.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8317678A9700E84674 /* FKFlickrGroupsDiscussTopicsAdd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55CF183191C500360DAC /* FKFlickrGroupsDiscussTopicsGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8517678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D0183191C500360DAC /* FKFlickrGroupsDiscussTopicsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8717678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D1183191C500360DAC /* FKFlickrGroupsBrowse.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8917678A9700E84674 /* FKFlickrGroupsBrowse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D2183191C500360DAC /* FKFlickrGroupsGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8B17678A9700E84674 /* FKFlickrGroupsGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D3183191C500360DAC /* FKFlickrGroupsJoin.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8D17678A9700E84674 /* FKFlickrGroupsJoin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D4183191C500360DAC /* FKFlickrGroupsJoinRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D8F17678A9700E84674 /* FKFlickrGroupsJoinRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D5183191C500360DAC /* FKFlickrGroupsLeave.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9117678A9700E84674 /* FKFlickrGroupsLeave.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D6183191C500360DAC /* FKFlickrGroupsSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9317678A9700E84674 /* FKFlickrGroupsSearch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D7183191C500360DAC /* FKFlickrGroupsMembersGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9617678A9700E84674 /* FKFlickrGroupsMembersGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D8183191C500360DAC /* FKFlickrGroupsPoolsAdd.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9917678A9700E84674 /* FKFlickrGroupsPoolsAdd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55D9183191C500360DAC /* FKFlickrGroupsPoolsGetContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9B17678A9700E84674 /* FKFlickrGroupsPoolsGetContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55DA183191C500360DAC /* FKFlickrGroupsPoolsGetGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9D17678A9700E84674 /* FKFlickrGroupsPoolsGetGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55DB183191C500360DAC /* FKFlickrGroupsPoolsGetPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2D9F17678A9700E84674 /* FKFlickrGroupsPoolsGetPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55DC183191C500360DAC /* FKFlickrGroupsPoolsRemove.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DA117678A9700E84674 /* FKFlickrGroupsPoolsRemove.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55DD183191C500360DAC /* FKFlickrInterestingnessGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DA417678A9700E84674 /* FKFlickrInterestingnessGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55DE183191C500360DAC /* FKFlickrMachinetagsGetNamespaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DA717678A9700E84674 /* FKFlickrMachinetagsGetNamespaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55DF183191C500360DAC /* FKFlickrMachinetagsGetPairs.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DA917678A9700E84674 /* FKFlickrMachinetagsGetPairs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E0183191C500360DAC /* FKFlickrMachinetagsGetPredicates.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DAB17678A9700E84674 /* FKFlickrMachinetagsGetPredicates.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E1183191C500360DAC /* FKFlickrMachinetagsGetRecentValues.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DAD17678A9700E84674 /* FKFlickrMachinetagsGetRecentValues.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E2183191C500360DAC /* FKFlickrMachinetagsGetValues.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DAF17678A9700E84674 /* FKFlickrMachinetagsGetValues.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E3183191C500360DAC /* FKFlickrPandaGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DB217678A9700E84674 /* FKFlickrPandaGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E4183191C500360DAC /* FKFlickrPandaGetPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DB417678A9700E84674 /* FKFlickrPandaGetPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E5183191C500360DAC /* FKFlickrPeopleFindByEmail.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DB717678A9700E84674 /* FKFlickrPeopleFindByEmail.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E6183191C500360DAC /* FKFlickrPeopleFindByUsername.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DB917678A9700E84674 /* FKFlickrPeopleFindByUsername.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E7183191C500360DAC /* FKFlickrPeopleGetGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DBB17678A9700E84674 /* FKFlickrPeopleGetGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E8183191C500360DAC /* FKFlickrPeopleGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DBD17678A9700E84674 /* FKFlickrPeopleGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55E9183191C500360DAC /* FKFlickrPeopleGetLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DBF17678A9700E84674 /* FKFlickrPeopleGetLimits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55EA183191C500360DAC /* FKFlickrPeopleGetPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DC117678A9700E84674 /* FKFlickrPeopleGetPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55EB183191C500360DAC /* FKFlickrPeopleGetPhotosOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DC317678A9700E84674 /* FKFlickrPeopleGetPhotosOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55EC183191C500360DAC /* FKFlickrPeopleGetPublicGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DC517678A9700E84674 /* FKFlickrPeopleGetPublicGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55ED183191C500360DAC /* FKFlickrPeopleGetPublicPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DC717678A9700E84674 /* FKFlickrPeopleGetPublicPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55EE183191C500360DAC /* FKFlickrPeopleGetUploadStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DC917678A9700E84674 /* FKFlickrPeopleGetUploadStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55EF183191DA00360DAC /* FKFlickrPhotosCommentsAddComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DCD17678A9700E84674 /* FKFlickrPhotosCommentsAddComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F0183191DA00360DAC /* FKFlickrPhotosCommentsDeleteComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DCF17678A9700E84674 /* FKFlickrPhotosCommentsDeleteComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F1183191DA00360DAC /* FKFlickrPhotosCommentsEditComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DD117678A9700E84674 /* FKFlickrPhotosCommentsEditComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F2183191DA00360DAC /* FKFlickrPhotosCommentsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DD317678A9700E84674 /* FKFlickrPhotosCommentsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F3183191DA00360DAC /* FKFlickrPhotosCommentsGetRecentForContacts.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DD517678A9700E84674 /* FKFlickrPhotosCommentsGetRecentForContacts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F4183191E300360DAC /* FKFlickrPhotosAddTags.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DD717678A9700E84674 /* FKFlickrPhotosAddTags.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F5183191E300360DAC /* FKFlickrPhotosDelete.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DD917678A9700E84674 /* FKFlickrPhotosDelete.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F6183191E300360DAC /* FKFlickrPhotosGetAllContexts.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DDB17678A9700E84674 /* FKFlickrPhotosGetAllContexts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F7183191E300360DAC /* FKFlickrPhotosGetContactsPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DDD17678A9700E84674 /* FKFlickrPhotosGetContactsPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F8183191E300360DAC /* FKFlickrPhotosGetContactsPublicPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DDF17678A9700E84674 /* FKFlickrPhotosGetContactsPublicPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55F9183191E300360DAC /* FKFlickrPhotosGetContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DE117678A9700E84674 /* FKFlickrPhotosGetContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55FA183191E300360DAC /* FKFlickrPhotosGetCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DE317678A9700E84674 /* FKFlickrPhotosGetCounts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55FB183191E300360DAC /* FKFlickrPhotosGetExif.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DE517678A9700E84674 /* FKFlickrPhotosGetExif.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55FC183191E300360DAC /* FKFlickrPhotosGetFavorites.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DE717678A9700E84674 /* FKFlickrPhotosGetFavorites.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55FD183191E300360DAC /* FKFlickrPhotosGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DE917678A9700E84674 /* FKFlickrPhotosGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55FE183191E300360DAC /* FKFlickrPhotosGetNotInSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DEB17678A9700E84674 /* FKFlickrPhotosGetNotInSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B55FF183191E300360DAC /* FKFlickrPhotosGetPerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DED17678A9700E84674 /* FKFlickrPhotosGetPerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5600183191E300360DAC /* FKFlickrPhotosGetRecent.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DEF17678A9700E84674 /* FKFlickrPhotosGetRecent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5601183191E300360DAC /* FKFlickrPhotosGetSizes.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DF117678A9700E84674 /* FKFlickrPhotosGetSizes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5602183191E300360DAC /* FKFlickrPhotosGetUntagged.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DF317678A9700E84674 /* FKFlickrPhotosGetUntagged.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5603183191E300360DAC /* FKFlickrPhotosGetWithGeoData.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DF517678A9700E84674 /* FKFlickrPhotosGetWithGeoData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5604183191E300360DAC /* FKFlickrPhotosGetWithoutGeoData.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DF717678A9700E84674 /* FKFlickrPhotosGetWithoutGeoData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5605183191E300360DAC /* FKFlickrPhotosRecentlyUpdated.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DF917678A9700E84674 /* FKFlickrPhotosRecentlyUpdated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5606183191E300360DAC /* FKFlickrPhotosRemoveTag.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DFB17678A9700E84674 /* FKFlickrPhotosRemoveTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5607183191E300360DAC /* FKFlickrPhotosSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DFD17678A9700E84674 /* FKFlickrPhotosSearch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5608183191E300360DAC /* FKFlickrPhotosSetContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2DFF17678A9700E84674 /* FKFlickrPhotosSetContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5609183191E300360DAC /* FKFlickrPhotosSetDates.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0117678A9700E84674 /* FKFlickrPhotosSetDates.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B560A183191E300360DAC /* FKFlickrPhotosSetMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0317678A9700E84674 /* FKFlickrPhotosSetMeta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B560B183191E300360DAC /* FKFlickrPhotosSetPerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0517678A9700E84674 /* FKFlickrPhotosSetPerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B560C183191E300360DAC /* FKFlickrPhotosSetSafetyLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0717678A9700E84674 /* FKFlickrPhotosSetSafetyLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B560D183191E300360DAC /* FKFlickrPhotosSetTags.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0917678A9700E84674 /* FKFlickrPhotosSetTags.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B560E183191FA00360DAC /* FKFlickrPhotosGeoBatchCorrectLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0D17678A9700E84674 /* FKFlickrPhotosGeoBatchCorrectLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B560F183191FA00360DAC /* FKFlickrPhotosGeoCorrectLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E0F17678A9700E84674 /* FKFlickrPhotosGeoCorrectLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5610183191FA00360DAC /* FKFlickrPhotosGeoGetLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1117678A9700E84674 /* FKFlickrPhotosGeoGetLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5611183191FA00360DAC /* FKFlickrPhotosGeoGetPerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1317678A9700E84674 /* FKFlickrPhotosGeoGetPerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5612183191FA00360DAC /* FKFlickrPhotosGeoPhotosForLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1517678A9700E84674 /* FKFlickrPhotosGeoPhotosForLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5613183191FA00360DAC /* FKFlickrPhotosGeoRemoveLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1717678A9700E84674 /* FKFlickrPhotosGeoRemoveLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5614183191FA00360DAC /* FKFlickrPhotosGeoSetContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1917678A9700E84674 /* FKFlickrPhotosGeoSetContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5615183191FA00360DAC /* FKFlickrPhotosGeoSetLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1B17678A9700E84674 /* FKFlickrPhotosGeoSetLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B5616183191FA00360DAC /* FKFlickrPhotosGeoSetPerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E1D17678A9700E84674 /* FKFlickrPhotosGeoSetPerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56171831921300360DAC /* FKFlickrPhotosLicensesGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2017678A9700E84674 /* FKFlickrPhotosLicensesGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56181831921300360DAC /* FKFlickrPhotosLicensesSetLicense.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2217678A9700E84674 /* FKFlickrPhotosLicensesSetLicense.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56191831921300360DAC /* FKFlickrPhotosNotesAdd.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2517678A9700E84674 /* FKFlickrPhotosNotesAdd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B561A1831921300360DAC /* FKFlickrPhotosNotesDelete.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2717678A9700E84674 /* FKFlickrPhotosNotesDelete.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B561B1831921300360DAC /* FKFlickrPhotosNotesEdit.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2917678A9700E84674 /* FKFlickrPhotosNotesEdit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B561C1831921300360DAC /* FKFlickrPhotosPeopleAdd.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2C17678A9700E84674 /* FKFlickrPhotosPeopleAdd.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B561D1831921300360DAC /* FKFlickrPhotosPeopleDelete.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E2E17678A9700E84674 /* FKFlickrPhotosPeopleDelete.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B561E1831921300360DAC /* FKFlickrPhotosPeopleDeleteCoords.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3017678A9700E84674 /* FKFlickrPhotosPeopleDeleteCoords.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B561F1831921300360DAC /* FKFlickrPhotosPeopleEditCoords.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3217678A9700E84674 /* FKFlickrPhotosPeopleEditCoords.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56201831921300360DAC /* FKFlickrPhotosPeopleGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3417678A9700E84674 /* FKFlickrPhotosPeopleGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56211831921300360DAC /* FKFlickrPhotosSuggestionsApproveSuggestion.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3717678A9700E84674 /* FKFlickrPhotosSuggestionsApproveSuggestion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56221831921300360DAC /* FKFlickrPhotosSuggestionsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3917678A9700E84674 /* FKFlickrPhotosSuggestionsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56231831921300360DAC /* FKFlickrPhotosSuggestionsRejectSuggestion.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3B17678A9700E84674 /* FKFlickrPhotosSuggestionsRejectSuggestion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56241831921300360DAC /* FKFlickrPhotosSuggestionsRemoveSuggestion.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3D17678A9700E84674 /* FKFlickrPhotosSuggestionsRemoveSuggestion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56251831921300360DAC /* FKFlickrPhotosSuggestionsSuggestLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E3F17678A9700E84674 /* FKFlickrPhotosSuggestionsSuggestLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56261831921300360DAC /* FKFlickrPhotosTransformRotate.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E4217678A9700E84674 /* FKFlickrPhotosTransformRotate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56271831921300360DAC /* FKFlickrPhotosUploadCheckTickets.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E4517678A9700E84674 /* FKFlickrPhotosUploadCheckTickets.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56281831921300360DAC /* FKFlickrPhotosetsCommentsAddComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E4917678A9700E84674 /* FKFlickrPhotosetsCommentsAddComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56291831921300360DAC /* FKFlickrPhotosetsCommentsDeleteComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E4B17678A9700E84674 /* FKFlickrPhotosetsCommentsDeleteComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B562A1831921300360DAC /* FKFlickrPhotosetsCommentsEditComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E4D17678A9700E84674 /* FKFlickrPhotosetsCommentsEditComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B562B1831921300360DAC /* FKFlickrPhotosetsCommentsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E4F17678A9700E84674 /* FKFlickrPhotosetsCommentsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B562C1831922B00360DAC /* FKFlickrPhotosetsAddPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5117678A9700E84674 /* FKFlickrPhotosetsAddPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B562D1831922B00360DAC /* FKFlickrPhotosetsCreate.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5317678A9700E84674 /* FKFlickrPhotosetsCreate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B562E1831922B00360DAC /* FKFlickrPhotosetsDelete.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5517678A9700E84674 /* FKFlickrPhotosetsDelete.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B562F1831922B00360DAC /* FKFlickrPhotosetsEditMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5717678A9700E84674 /* FKFlickrPhotosetsEditMeta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56301831922B00360DAC /* FKFlickrPhotosetsEditPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5917678A9700E84674 /* FKFlickrPhotosetsEditPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56311831922B00360DAC /* FKFlickrPhotosetsGetContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5B17678A9700E84674 /* FKFlickrPhotosetsGetContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56321831922B00360DAC /* FKFlickrPhotosetsGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5D17678A9700E84674 /* FKFlickrPhotosetsGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56331831922B00360DAC /* FKFlickrPhotosetsGetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E5F17678A9700E84674 /* FKFlickrPhotosetsGetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56341831922B00360DAC /* FKFlickrPhotosetsGetPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6117678A9700E84674 /* FKFlickrPhotosetsGetPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56351831922B00360DAC /* FKFlickrPhotosetsOrderSets.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6317678A9700E84674 /* FKFlickrPhotosetsOrderSets.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56361831922B00360DAC /* FKFlickrPhotosetsRemovePhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6517678A9700E84674 /* FKFlickrPhotosetsRemovePhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56371831922B00360DAC /* FKFlickrPhotosetsRemovePhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6717678A9700E84674 /* FKFlickrPhotosetsRemovePhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56381831922B00360DAC /* FKFlickrPhotosetsReorderPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6917678A9700E84674 /* FKFlickrPhotosetsReorderPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56391831922B00360DAC /* FKFlickrPhotosetsSetPrimaryPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6B17678A9700E84674 /* FKFlickrPhotosetsSetPrimaryPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B563A1831923C00360DAC /* FKFlickrPlacesFind.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E6E17678A9700E84674 /* FKFlickrPlacesFind.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B563B1831923C00360DAC /* FKFlickrPlacesFindByLatLon.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7017678A9700E84674 /* FKFlickrPlacesFindByLatLon.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B563C1831923C00360DAC /* FKFlickrPlacesGetChildrenWithPhotosPublic.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7217678A9700E84674 /* FKFlickrPlacesGetChildrenWithPhotosPublic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B563D1831923C00360DAC /* FKFlickrPlacesGetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7417678A9700E84674 /* FKFlickrPlacesGetInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B563E1831923C00360DAC /* FKFlickrPlacesGetInfoByUrl.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7617678A9700E84674 /* FKFlickrPlacesGetInfoByUrl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B563F1831923C00360DAC /* FKFlickrPlacesGetPlaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7817678A9700E84674 /* FKFlickrPlacesGetPlaceTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56401831923C00360DAC /* FKFlickrPlacesGetShapeHistory.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7A17678A9700E84674 /* FKFlickrPlacesGetShapeHistory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56411831923C00360DAC /* FKFlickrPlacesGetTopPlacesList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7C17678A9700E84674 /* FKFlickrPlacesGetTopPlacesList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56421831923C00360DAC /* FKFlickrPlacesPlacesForBoundingBox.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E7E17678A9700E84674 /* FKFlickrPlacesPlacesForBoundingBox.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56431831923C00360DAC /* FKFlickrPlacesPlacesForContacts.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8017678A9700E84674 /* FKFlickrPlacesPlacesForContacts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56441831923C00360DAC /* FKFlickrPlacesPlacesForTags.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8217678A9700E84674 /* FKFlickrPlacesPlacesForTags.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56451831923C00360DAC /* FKFlickrPlacesPlacesForUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8417678A9800E84674 /* FKFlickrPlacesPlacesForUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56461831923C00360DAC /* FKFlickrPlacesResolvePlaceId.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8617678A9800E84674 /* FKFlickrPlacesResolvePlaceId.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56471831923C00360DAC /* FKFlickrPlacesResolvePlaceURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8817678A9800E84674 /* FKFlickrPlacesResolvePlaceURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56481831923C00360DAC /* FKFlickrPlacesTagsForPlace.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8A17678A9800E84674 /* FKFlickrPlacesTagsForPlace.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56491831924A00360DAC /* FKFlickrPrefsGetContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8D17678A9800E84674 /* FKFlickrPrefsGetContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B564A1831924A00360DAC /* FKFlickrPrefsGetGeoPerms.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E8F17678A9800E84674 /* FKFlickrPrefsGetGeoPerms.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B564B1831924A00360DAC /* FKFlickrPrefsGetHidden.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9117678A9800E84674 /* FKFlickrPrefsGetHidden.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B564C1831924A00360DAC /* FKFlickrPrefsGetPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9317678A9800E84674 /* FKFlickrPrefsGetPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B564D1831924A00360DAC /* FKFlickrPrefsGetSafetyLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9517678A9800E84674 /* FKFlickrPrefsGetSafetyLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B564E1831925300360DAC /* FKFlickrPushGetSubscriptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9817678A9800E84674 /* FKFlickrPushGetSubscriptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B564F1831925300360DAC /* FKFlickrPushGetTopics.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9A17678A9800E84674 /* FKFlickrPushGetTopics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56501831925300360DAC /* FKFlickrPushSubscribe.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9C17678A9800E84674 /* FKFlickrPushSubscribe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56511831925300360DAC /* FKFlickrPushUnsubscribe.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2E9E17678A9800E84674 /* FKFlickrPushUnsubscribe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56521831925C00360DAC /* FKFlickrReflectionGetMethodInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EA117678A9800E84674 /* FKFlickrReflectionGetMethodInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56531831925C00360DAC /* FKFlickrReflectionGetMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EA317678A9800E84674 /* FKFlickrReflectionGetMethods.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56541831927200360DAC /* FKFlickrStatsGetCollectionDomains.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EA617678A9800E84674 /* FKFlickrStatsGetCollectionDomains.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56551831927200360DAC /* FKFlickrStatsGetCollectionReferrers.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EA817678A9800E84674 /* FKFlickrStatsGetCollectionReferrers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56561831927200360DAC /* FKFlickrStatsGetCollectionStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EAA17678A9800E84674 /* FKFlickrStatsGetCollectionStats.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56571831927200360DAC /* FKFlickrStatsGetCSVFiles.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EAC17678A9800E84674 /* FKFlickrStatsGetCSVFiles.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56581831927200360DAC /* FKFlickrStatsGetPhotoDomains.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EAE17678A9800E84674 /* FKFlickrStatsGetPhotoDomains.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56591831927200360DAC /* FKFlickrStatsGetPhotoReferrers.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EB017678A9800E84674 /* FKFlickrStatsGetPhotoReferrers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B565A1831927200360DAC /* FKFlickrStatsGetPhotosetDomains.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EB217678A9800E84674 /* FKFlickrStatsGetPhotosetDomains.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B565B1831927200360DAC /* FKFlickrStatsGetPhotosetReferrers.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EB417678A9800E84674 /* FKFlickrStatsGetPhotosetReferrers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B565C1831927200360DAC /* FKFlickrStatsGetPhotosetStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EB617678A9800E84674 /* FKFlickrStatsGetPhotosetStats.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B565D1831927200360DAC /* FKFlickrStatsGetPhotoStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EB817678A9800E84674 /* FKFlickrStatsGetPhotoStats.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B565E1831927200360DAC /* FKFlickrStatsGetPhotostreamDomains.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EBA17678A9800E84674 /* FKFlickrStatsGetPhotostreamDomains.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B565F1831927200360DAC /* FKFlickrStatsGetPhotostreamReferrers.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EBC17678A9800E84674 /* FKFlickrStatsGetPhotostreamReferrers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56601831927200360DAC /* FKFlickrStatsGetPhotostreamStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EBE17678A9800E84674 /* FKFlickrStatsGetPhotostreamStats.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56611831927200360DAC /* FKFlickrStatsGetPopularPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EC017678A9800E84674 /* FKFlickrStatsGetPopularPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56621831927200360DAC /* FKFlickrStatsGetTotalViews.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EC217678A9800E84674 /* FKFlickrStatsGetTotalViews.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56631831927200360DAC /* FKFlickrTagsGetClusterPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EC517678A9800E84674 /* FKFlickrTagsGetClusterPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56641831927200360DAC /* FKFlickrTagsGetClusters.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EC717678A9800E84674 /* FKFlickrTagsGetClusters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56651831927200360DAC /* FKFlickrTagsGetHotList.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EC917678A9800E84674 /* FKFlickrTagsGetHotList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56661831927200360DAC /* FKFlickrTagsGetListPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ECB17678A9800E84674 /* FKFlickrTagsGetListPhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56671831927200360DAC /* FKFlickrTagsGetListUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ECD17678A9800E84674 /* FKFlickrTagsGetListUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56681831927200360DAC /* FKFlickrTagsGetListUserPopular.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ECF17678A9800E84674 /* FKFlickrTagsGetListUserPopular.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56691831927200360DAC /* FKFlickrTagsGetListUserRaw.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ED117678A9800E84674 /* FKFlickrTagsGetListUserRaw.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B566A1831927200360DAC /* FKFlickrTagsGetMostFrequentlyUsed.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ED317678A9800E84674 /* FKFlickrTagsGetMostFrequentlyUsed.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B566B1831927200360DAC /* FKFlickrTagsGetRelated.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ED517678A9800E84674 /* FKFlickrTagsGetRelated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B566C1831927200360DAC /* FKFlickrTestEcho.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2ED817678A9800E84674 /* FKFlickrTestEcho.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B566D1831927200360DAC /* FKFlickrTestLogin.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EDA17678A9800E84674 /* FKFlickrTestLogin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B566E1831927200360DAC /* FKFlickrTestNull.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EDC17678A9800E84674 /* FKFlickrTestNull.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B566F1831927200360DAC /* FKFlickrUrlsGetGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EDF17678A9800E84674 /* FKFlickrUrlsGetGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56701831927200360DAC /* FKFlickrUrlsGetUserPhotos.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EE117678A9800E84674 /* FKFlickrUrlsGetUserPhotos.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56711831927200360DAC /* FKFlickrUrlsGetUserProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EE317678A9800E84674 /* FKFlickrUrlsGetUserProfile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56721831927200360DAC /* FKFlickrUrlsLookupGallery.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EE517678A9800E84674 /* FKFlickrUrlsLookupGallery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56731831927200360DAC /* FKFlickrUrlsLookupGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EE717678A9800E84674 /* FKFlickrUrlsLookupGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56741831927200360DAC /* FKFlickrUrlsLookupUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 555F2EE917678A9800E84674 /* FKFlickrUrlsLookupUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56751831929100360DAC /* FKFlickrAPIMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = 555ADB1C1766640100AA91AB /* FKFlickrAPIMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56761831929100360DAC /* FKAPIMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 55958DEF1767BD7B0078905C /* FKAPIMethods.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56771831929100360DAC /* FKUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AEEF4E1756646400B61A3C /* FKUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56781831929100360DAC /* FKOFHMACSha1Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EA68AB17CAABD40017DDD1 /* FKOFHMACSha1Base64.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56791831929100360DAC /* FKDUDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D921A1754DC6500BE3FEA /* FKDUDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B567A1831929100360DAC /* FKDUDefaultDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D92161754DBAC00BE3FEA /* FKDUDefaultDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B567B1831929100360DAC /* FKDUBlocks.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91E61754AE8A00BE3FEA /* FKDUBlocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B567C1831929100360DAC /* FKDUConcurrentOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91E81754AE8A00BE3FEA /* FKDUConcurrentOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B567D1831929100360DAC /* FKDUNetworkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AD48E7175F3217004AF85C /* FKDUNetworkOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B567E1831929100360DAC /* FKDUNetworkController.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91EA1754AE8A00BE3FEA /* FKDUNetworkController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B567F1831929100360DAC /* FKDUStreamUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 55A5B666176613F900745C71 /* FKDUStreamUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56801831929100360DAC /* FKFlickrNetworkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91F11754AE8A00BE3FEA /* FKFlickrNetworkOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56811831929100360DAC /* FKImageUploadNetworkOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AD49041760DBE4004AF85C /* FKImageUploadNetworkOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56821831929100360DAC /* FKUploadRespone.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AD49081760E545004AF85C /* FKUploadRespone.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56831831929100360DAC /* FKURLBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91F31754AE8A00BE3FEA /* FKURLBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56841831929100360DAC /* FKDUReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AEEF55175766D500B61A3C /* FKDUReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56851831929100360DAC /* FKDataTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AD4849175CA188004AF85C /* FKDataTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56861831929100360DAC /* FlickrKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91EC1754AE8A00BE3FEA /* FlickrKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56871831929100360DAC /* FlickrKitUtilTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 55AEEF4A175661C100B61A3C /* FlickrKitUtilTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56881831929100360DAC /* FlickrKit_Tests.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D921D175504DF00BE3FEA /* FlickrKit_Tests.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B56891831929100360DAC /* FlickrKitTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91431753951300BE3FEA /* FlickrKitTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B568A1831929100360DAC /* FlickrKitFailTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D91631753B7EC00BE3FEA /* FlickrKitFailTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2B568B1831929100360DAC /* FlickrAuthTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 552D916A1753C5C900BE3FEA /* FlickrAuthTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B4ED7D618391C8800745B36 /* NSImageJPEGRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B4ED7D418391C8800745B36 /* NSImageJPEGRepresentation.h */; };
+		5B4ED7D718391C8800745B36 /* NSImageJPEGRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B4ED7D518391C8800745B36 /* NSImageJPEGRepresentation.m */; };
+		5B4ED7D818391FA100745B36 /* FlickrKitUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55AEEF4B175661C100B61A3C /* FlickrKitUtilTests.m */; };
+		5B4ED7D918391FA100745B36 /* FlickrKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91441753951300BE3FEA /* FlickrKitTests.m */; };
+		5B4ED7DA18391FA100745B36 /* FlickrKitFailTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D91641753B7EC00BE3FEA /* FlickrKitFailTests.m */; };
+		5B4ED7DB18391FA100745B36 /* FlickrAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 552D916B1753C5C900BE3FEA /* FlickrAuthTests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		5B2B54AB1831801C00360DAC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 552D910E1753951300BE3FEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B2B54911831801B00360DAC;
+			remoteInfo = "FlickrKit Framework";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		552D911B1753951300BE3FEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		552D911D1753951300BE3FEA /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		552D91371753951300BE3FEA /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		552D91431753951300BE3FEA /* FlickrKitTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FlickrKitTests.h; sourceTree = "<group>"; };
+		552D91441753951300BE3FEA /* FlickrKitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FlickrKitTests.m; sourceTree = "<group>"; };
+		552D91631753B7EC00BE3FEA /* FlickrKitFailTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlickrKitFailTests.h; sourceTree = "<group>"; };
+		552D91641753B7EC00BE3FEA /* FlickrKitFailTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlickrKitFailTests.m; sourceTree = "<group>"; };
+		552D916A1753C5C900BE3FEA /* FlickrAuthTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlickrAuthTests.h; sourceTree = "<group>"; };
+		552D916B1753C5C900BE3FEA /* FlickrAuthTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlickrAuthTests.m; sourceTree = "<group>"; };
+		552D91E61754AE8A00BE3FEA /* FKDUBlocks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUBlocks.h; sourceTree = "<group>"; };
+		552D91E71754AE8A00BE3FEA /* FKDUBlocks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUBlocks.m; sourceTree = "<group>"; };
+		552D91E81754AE8A00BE3FEA /* FKDUConcurrentOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUConcurrentOperation.h; sourceTree = "<group>"; };
+		552D91E91754AE8A00BE3FEA /* FKDUConcurrentOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUConcurrentOperation.m; sourceTree = "<group>"; };
+		552D91EA1754AE8A00BE3FEA /* FKDUNetworkController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUNetworkController.h; sourceTree = "<group>"; };
+		552D91EB1754AE8A00BE3FEA /* FKDUNetworkController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUNetworkController.m; sourceTree = "<group>"; };
+		552D91EC1754AE8A00BE3FEA /* FlickrKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlickrKit.h; sourceTree = "<group>"; };
+		552D91F11754AE8A00BE3FEA /* FKFlickrNetworkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrNetworkOperation.h; sourceTree = "<group>"; };
+		552D91F21754AE8A00BE3FEA /* FKFlickrNetworkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrNetworkOperation.m; sourceTree = "<group>"; };
+		552D91F31754AE8A00BE3FEA /* FKURLBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKURLBuilder.h; sourceTree = "<group>"; };
+		552D91F41754AE8A00BE3FEA /* FKURLBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKURLBuilder.m; sourceTree = "<group>"; };
+		552D92161754DBAC00BE3FEA /* FKDUDefaultDiskCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUDefaultDiskCache.h; sourceTree = "<group>"; };
+		552D92171754DBAC00BE3FEA /* FKDUDefaultDiskCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUDefaultDiskCache.m; sourceTree = "<group>"; };
+		552D921A1754DC6500BE3FEA /* FKDUDiskCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUDiskCache.h; sourceTree = "<group>"; };
+		552D921D175504DF00BE3FEA /* FlickrKit_Tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlickrKit_Tests.h; sourceTree = "<group>"; };
+		555ADB1C1766640100AA91AB /* FKFlickrAPIMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKFlickrAPIMethod.h; path = Model/FKFlickrAPIMethod.h; sourceTree = "<group>"; };
+		555F2D2817678A9700E84674 /* FKFlickrActivityUserComments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrActivityUserComments.h; sourceTree = "<group>"; };
+		555F2D2917678A9700E84674 /* FKFlickrActivityUserComments.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrActivityUserComments.m; sourceTree = "<group>"; };
+		555F2D2A17678A9700E84674 /* FKFlickrActivityUserPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrActivityUserPhotos.h; sourceTree = "<group>"; };
+		555F2D2B17678A9700E84674 /* FKFlickrActivityUserPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrActivityUserPhotos.m; sourceTree = "<group>"; };
+		555F2D2D17678A9700E84674 /* FKFlickrAuthCheckToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrAuthCheckToken.h; sourceTree = "<group>"; };
+		555F2D2E17678A9700E84674 /* FKFlickrAuthCheckToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrAuthCheckToken.m; sourceTree = "<group>"; };
+		555F2D2F17678A9700E84674 /* FKFlickrAuthGetFrob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrAuthGetFrob.h; sourceTree = "<group>"; };
+		555F2D3017678A9700E84674 /* FKFlickrAuthGetFrob.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrAuthGetFrob.m; sourceTree = "<group>"; };
+		555F2D3117678A9700E84674 /* FKFlickrAuthGetFullToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrAuthGetFullToken.h; sourceTree = "<group>"; };
+		555F2D3217678A9700E84674 /* FKFlickrAuthGetFullToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrAuthGetFullToken.m; sourceTree = "<group>"; };
+		555F2D3317678A9700E84674 /* FKFlickrAuthGetToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrAuthGetToken.h; sourceTree = "<group>"; };
+		555F2D3417678A9700E84674 /* FKFlickrAuthGetToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrAuthGetToken.m; sourceTree = "<group>"; };
+		555F2D3617678A9700E84674 /* FKFlickrAuthOauthCheckToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrAuthOauthCheckToken.h; sourceTree = "<group>"; };
+		555F2D3717678A9700E84674 /* FKFlickrAuthOauthCheckToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrAuthOauthCheckToken.m; sourceTree = "<group>"; };
+		555F2D3817678A9700E84674 /* FKFlickrAuthOauthGetAccessToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrAuthOauthGetAccessToken.h; sourceTree = "<group>"; };
+		555F2D3917678A9700E84674 /* FKFlickrAuthOauthGetAccessToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrAuthOauthGetAccessToken.m; sourceTree = "<group>"; };
+		555F2D3B17678A9700E84674 /* FKFlickrBlogsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrBlogsGetList.h; sourceTree = "<group>"; };
+		555F2D3C17678A9700E84674 /* FKFlickrBlogsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrBlogsGetList.m; sourceTree = "<group>"; };
+		555F2D3D17678A9700E84674 /* FKFlickrBlogsGetServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrBlogsGetServices.h; sourceTree = "<group>"; };
+		555F2D3E17678A9700E84674 /* FKFlickrBlogsGetServices.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrBlogsGetServices.m; sourceTree = "<group>"; };
+		555F2D3F17678A9700E84674 /* FKFlickrBlogsPostPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrBlogsPostPhoto.h; sourceTree = "<group>"; };
+		555F2D4017678A9700E84674 /* FKFlickrBlogsPostPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrBlogsPostPhoto.m; sourceTree = "<group>"; };
+		555F2D4217678A9700E84674 /* FKFlickrCamerasGetBrandModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrCamerasGetBrandModels.h; sourceTree = "<group>"; };
+		555F2D4317678A9700E84674 /* FKFlickrCamerasGetBrandModels.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrCamerasGetBrandModels.m; sourceTree = "<group>"; };
+		555F2D4417678A9700E84674 /* FKFlickrCamerasGetBrands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrCamerasGetBrands.h; sourceTree = "<group>"; };
+		555F2D4517678A9700E84674 /* FKFlickrCamerasGetBrands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrCamerasGetBrands.m; sourceTree = "<group>"; };
+		555F2D4717678A9700E84674 /* FKFlickrCollectionsGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrCollectionsGetInfo.h; sourceTree = "<group>"; };
+		555F2D4817678A9700E84674 /* FKFlickrCollectionsGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrCollectionsGetInfo.m; sourceTree = "<group>"; };
+		555F2D4917678A9700E84674 /* FKFlickrCollectionsGetTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrCollectionsGetTree.h; sourceTree = "<group>"; };
+		555F2D4A17678A9700E84674 /* FKFlickrCollectionsGetTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrCollectionsGetTree.m; sourceTree = "<group>"; };
+		555F2D4C17678A9700E84674 /* FKFlickrCommonsGetInstitutions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrCommonsGetInstitutions.h; sourceTree = "<group>"; };
+		555F2D4D17678A9700E84674 /* FKFlickrCommonsGetInstitutions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrCommonsGetInstitutions.m; sourceTree = "<group>"; };
+		555F2D4F17678A9700E84674 /* FKFlickrContactsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrContactsGetList.h; sourceTree = "<group>"; };
+		555F2D5017678A9700E84674 /* FKFlickrContactsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrContactsGetList.m; sourceTree = "<group>"; };
+		555F2D5117678A9700E84674 /* FKFlickrContactsGetListRecentlyUploaded.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrContactsGetListRecentlyUploaded.h; sourceTree = "<group>"; };
+		555F2D5217678A9700E84674 /* FKFlickrContactsGetListRecentlyUploaded.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrContactsGetListRecentlyUploaded.m; sourceTree = "<group>"; };
+		555F2D5317678A9700E84674 /* FKFlickrContactsGetPublicList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrContactsGetPublicList.h; sourceTree = "<group>"; };
+		555F2D5417678A9700E84674 /* FKFlickrContactsGetPublicList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrContactsGetPublicList.m; sourceTree = "<group>"; };
+		555F2D5517678A9700E84674 /* FKFlickrContactsGetTaggingSuggestions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrContactsGetTaggingSuggestions.h; sourceTree = "<group>"; };
+		555F2D5617678A9700E84674 /* FKFlickrContactsGetTaggingSuggestions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrContactsGetTaggingSuggestions.m; sourceTree = "<group>"; };
+		555F2D5817678A9700E84674 /* FKFlickrFavoritesAdd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrFavoritesAdd.h; sourceTree = "<group>"; };
+		555F2D5917678A9700E84674 /* FKFlickrFavoritesAdd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrFavoritesAdd.m; sourceTree = "<group>"; };
+		555F2D5A17678A9700E84674 /* FKFlickrFavoritesGetContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrFavoritesGetContext.h; sourceTree = "<group>"; };
+		555F2D5B17678A9700E84674 /* FKFlickrFavoritesGetContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrFavoritesGetContext.m; sourceTree = "<group>"; };
+		555F2D5C17678A9700E84674 /* FKFlickrFavoritesGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrFavoritesGetList.h; sourceTree = "<group>"; };
+		555F2D5D17678A9700E84674 /* FKFlickrFavoritesGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrFavoritesGetList.m; sourceTree = "<group>"; };
+		555F2D5E17678A9700E84674 /* FKFlickrFavoritesGetPublicList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrFavoritesGetPublicList.h; sourceTree = "<group>"; };
+		555F2D5F17678A9700E84674 /* FKFlickrFavoritesGetPublicList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrFavoritesGetPublicList.m; sourceTree = "<group>"; };
+		555F2D6017678A9700E84674 /* FKFlickrFavoritesRemove.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrFavoritesRemove.h; sourceTree = "<group>"; };
+		555F2D6117678A9700E84674 /* FKFlickrFavoritesRemove.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrFavoritesRemove.m; sourceTree = "<group>"; };
+		555F2D6317678A9700E84674 /* FKFlickrGalleriesAddPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesAddPhoto.h; sourceTree = "<group>"; };
+		555F2D6417678A9700E84674 /* FKFlickrGalleriesAddPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesAddPhoto.m; sourceTree = "<group>"; };
+		555F2D6517678A9700E84674 /* FKFlickrGalleriesCreate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesCreate.h; sourceTree = "<group>"; };
+		555F2D6617678A9700E84674 /* FKFlickrGalleriesCreate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesCreate.m; sourceTree = "<group>"; };
+		555F2D6717678A9700E84674 /* FKFlickrGalleriesEditMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesEditMeta.h; sourceTree = "<group>"; };
+		555F2D6817678A9700E84674 /* FKFlickrGalleriesEditMeta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesEditMeta.m; sourceTree = "<group>"; };
+		555F2D6917678A9700E84674 /* FKFlickrGalleriesEditPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesEditPhoto.h; sourceTree = "<group>"; };
+		555F2D6A17678A9700E84674 /* FKFlickrGalleriesEditPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesEditPhoto.m; sourceTree = "<group>"; };
+		555F2D6B17678A9700E84674 /* FKFlickrGalleriesEditPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesEditPhotos.h; sourceTree = "<group>"; };
+		555F2D6C17678A9700E84674 /* FKFlickrGalleriesEditPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesEditPhotos.m; sourceTree = "<group>"; };
+		555F2D6D17678A9700E84674 /* FKFlickrGalleriesGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesGetInfo.h; sourceTree = "<group>"; };
+		555F2D6E17678A9700E84674 /* FKFlickrGalleriesGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesGetInfo.m; sourceTree = "<group>"; };
+		555F2D6F17678A9700E84674 /* FKFlickrGalleriesGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesGetList.h; sourceTree = "<group>"; };
+		555F2D7017678A9700E84674 /* FKFlickrGalleriesGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesGetList.m; sourceTree = "<group>"; };
+		555F2D7117678A9700E84674 /* FKFlickrGalleriesGetListForPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesGetListForPhoto.h; sourceTree = "<group>"; };
+		555F2D7217678A9700E84674 /* FKFlickrGalleriesGetListForPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesGetListForPhoto.m; sourceTree = "<group>"; };
+		555F2D7317678A9700E84674 /* FKFlickrGalleriesGetPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGalleriesGetPhotos.h; sourceTree = "<group>"; };
+		555F2D7417678A9700E84674 /* FKFlickrGalleriesGetPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGalleriesGetPhotos.m; sourceTree = "<group>"; };
+		555F2D7817678A9700E84674 /* FKFlickrGroupsDiscussRepliesAdd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussRepliesAdd.h; sourceTree = "<group>"; };
+		555F2D7917678A9700E84674 /* FKFlickrGroupsDiscussRepliesAdd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussRepliesAdd.m; sourceTree = "<group>"; };
+		555F2D7A17678A9700E84674 /* FKFlickrGroupsDiscussRepliesDelete.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussRepliesDelete.h; sourceTree = "<group>"; };
+		555F2D7B17678A9700E84674 /* FKFlickrGroupsDiscussRepliesDelete.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussRepliesDelete.m; sourceTree = "<group>"; };
+		555F2D7C17678A9700E84674 /* FKFlickrGroupsDiscussRepliesEdit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussRepliesEdit.h; sourceTree = "<group>"; };
+		555F2D7D17678A9700E84674 /* FKFlickrGroupsDiscussRepliesEdit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussRepliesEdit.m; sourceTree = "<group>"; };
+		555F2D7E17678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussRepliesGetInfo.h; sourceTree = "<group>"; };
+		555F2D7F17678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussRepliesGetInfo.m; sourceTree = "<group>"; };
+		555F2D8017678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussRepliesGetList.h; sourceTree = "<group>"; };
+		555F2D8117678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussRepliesGetList.m; sourceTree = "<group>"; };
+		555F2D8317678A9700E84674 /* FKFlickrGroupsDiscussTopicsAdd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussTopicsAdd.h; sourceTree = "<group>"; };
+		555F2D8417678A9700E84674 /* FKFlickrGroupsDiscussTopicsAdd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussTopicsAdd.m; sourceTree = "<group>"; };
+		555F2D8517678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussTopicsGetInfo.h; sourceTree = "<group>"; };
+		555F2D8617678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussTopicsGetInfo.m; sourceTree = "<group>"; };
+		555F2D8717678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsDiscussTopicsGetList.h; sourceTree = "<group>"; };
+		555F2D8817678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsDiscussTopicsGetList.m; sourceTree = "<group>"; };
+		555F2D8917678A9700E84674 /* FKFlickrGroupsBrowse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsBrowse.h; sourceTree = "<group>"; };
+		555F2D8A17678A9700E84674 /* FKFlickrGroupsBrowse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsBrowse.m; sourceTree = "<group>"; };
+		555F2D8B17678A9700E84674 /* FKFlickrGroupsGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsGetInfo.h; sourceTree = "<group>"; };
+		555F2D8C17678A9700E84674 /* FKFlickrGroupsGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsGetInfo.m; sourceTree = "<group>"; };
+		555F2D8D17678A9700E84674 /* FKFlickrGroupsJoin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsJoin.h; sourceTree = "<group>"; };
+		555F2D8E17678A9700E84674 /* FKFlickrGroupsJoin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsJoin.m; sourceTree = "<group>"; };
+		555F2D8F17678A9700E84674 /* FKFlickrGroupsJoinRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsJoinRequest.h; sourceTree = "<group>"; };
+		555F2D9017678A9700E84674 /* FKFlickrGroupsJoinRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsJoinRequest.m; sourceTree = "<group>"; };
+		555F2D9117678A9700E84674 /* FKFlickrGroupsLeave.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsLeave.h; sourceTree = "<group>"; };
+		555F2D9217678A9700E84674 /* FKFlickrGroupsLeave.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsLeave.m; sourceTree = "<group>"; };
+		555F2D9317678A9700E84674 /* FKFlickrGroupsSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsSearch.h; sourceTree = "<group>"; };
+		555F2D9417678A9700E84674 /* FKFlickrGroupsSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsSearch.m; sourceTree = "<group>"; };
+		555F2D9617678A9700E84674 /* FKFlickrGroupsMembersGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsMembersGetList.h; sourceTree = "<group>"; };
+		555F2D9717678A9700E84674 /* FKFlickrGroupsMembersGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsMembersGetList.m; sourceTree = "<group>"; };
+		555F2D9917678A9700E84674 /* FKFlickrGroupsPoolsAdd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsPoolsAdd.h; sourceTree = "<group>"; };
+		555F2D9A17678A9700E84674 /* FKFlickrGroupsPoolsAdd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsPoolsAdd.m; sourceTree = "<group>"; };
+		555F2D9B17678A9700E84674 /* FKFlickrGroupsPoolsGetContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsPoolsGetContext.h; sourceTree = "<group>"; };
+		555F2D9C17678A9700E84674 /* FKFlickrGroupsPoolsGetContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsPoolsGetContext.m; sourceTree = "<group>"; };
+		555F2D9D17678A9700E84674 /* FKFlickrGroupsPoolsGetGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsPoolsGetGroups.h; sourceTree = "<group>"; };
+		555F2D9E17678A9700E84674 /* FKFlickrGroupsPoolsGetGroups.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsPoolsGetGroups.m; sourceTree = "<group>"; };
+		555F2D9F17678A9700E84674 /* FKFlickrGroupsPoolsGetPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsPoolsGetPhotos.h; sourceTree = "<group>"; };
+		555F2DA017678A9700E84674 /* FKFlickrGroupsPoolsGetPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsPoolsGetPhotos.m; sourceTree = "<group>"; };
+		555F2DA117678A9700E84674 /* FKFlickrGroupsPoolsRemove.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrGroupsPoolsRemove.h; sourceTree = "<group>"; };
+		555F2DA217678A9700E84674 /* FKFlickrGroupsPoolsRemove.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrGroupsPoolsRemove.m; sourceTree = "<group>"; };
+		555F2DA417678A9700E84674 /* FKFlickrInterestingnessGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrInterestingnessGetList.h; sourceTree = "<group>"; };
+		555F2DA517678A9700E84674 /* FKFlickrInterestingnessGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrInterestingnessGetList.m; sourceTree = "<group>"; };
+		555F2DA717678A9700E84674 /* FKFlickrMachinetagsGetNamespaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrMachinetagsGetNamespaces.h; sourceTree = "<group>"; };
+		555F2DA817678A9700E84674 /* FKFlickrMachinetagsGetNamespaces.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrMachinetagsGetNamespaces.m; sourceTree = "<group>"; };
+		555F2DA917678A9700E84674 /* FKFlickrMachinetagsGetPairs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrMachinetagsGetPairs.h; sourceTree = "<group>"; };
+		555F2DAA17678A9700E84674 /* FKFlickrMachinetagsGetPairs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrMachinetagsGetPairs.m; sourceTree = "<group>"; };
+		555F2DAB17678A9700E84674 /* FKFlickrMachinetagsGetPredicates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrMachinetagsGetPredicates.h; sourceTree = "<group>"; };
+		555F2DAC17678A9700E84674 /* FKFlickrMachinetagsGetPredicates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrMachinetagsGetPredicates.m; sourceTree = "<group>"; };
+		555F2DAD17678A9700E84674 /* FKFlickrMachinetagsGetRecentValues.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrMachinetagsGetRecentValues.h; sourceTree = "<group>"; };
+		555F2DAE17678A9700E84674 /* FKFlickrMachinetagsGetRecentValues.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrMachinetagsGetRecentValues.m; sourceTree = "<group>"; };
+		555F2DAF17678A9700E84674 /* FKFlickrMachinetagsGetValues.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrMachinetagsGetValues.h; sourceTree = "<group>"; };
+		555F2DB017678A9700E84674 /* FKFlickrMachinetagsGetValues.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrMachinetagsGetValues.m; sourceTree = "<group>"; };
+		555F2DB217678A9700E84674 /* FKFlickrPandaGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPandaGetList.h; sourceTree = "<group>"; };
+		555F2DB317678A9700E84674 /* FKFlickrPandaGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPandaGetList.m; sourceTree = "<group>"; };
+		555F2DB417678A9700E84674 /* FKFlickrPandaGetPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPandaGetPhotos.h; sourceTree = "<group>"; };
+		555F2DB517678A9700E84674 /* FKFlickrPandaGetPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPandaGetPhotos.m; sourceTree = "<group>"; };
+		555F2DB717678A9700E84674 /* FKFlickrPeopleFindByEmail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleFindByEmail.h; sourceTree = "<group>"; };
+		555F2DB817678A9700E84674 /* FKFlickrPeopleFindByEmail.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleFindByEmail.m; sourceTree = "<group>"; };
+		555F2DB917678A9700E84674 /* FKFlickrPeopleFindByUsername.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleFindByUsername.h; sourceTree = "<group>"; };
+		555F2DBA17678A9700E84674 /* FKFlickrPeopleFindByUsername.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleFindByUsername.m; sourceTree = "<group>"; };
+		555F2DBB17678A9700E84674 /* FKFlickrPeopleGetGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetGroups.h; sourceTree = "<group>"; };
+		555F2DBC17678A9700E84674 /* FKFlickrPeopleGetGroups.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetGroups.m; sourceTree = "<group>"; };
+		555F2DBD17678A9700E84674 /* FKFlickrPeopleGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetInfo.h; sourceTree = "<group>"; };
+		555F2DBE17678A9700E84674 /* FKFlickrPeopleGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetInfo.m; sourceTree = "<group>"; };
+		555F2DBF17678A9700E84674 /* FKFlickrPeopleGetLimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetLimits.h; sourceTree = "<group>"; };
+		555F2DC017678A9700E84674 /* FKFlickrPeopleGetLimits.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetLimits.m; sourceTree = "<group>"; };
+		555F2DC117678A9700E84674 /* FKFlickrPeopleGetPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetPhotos.h; sourceTree = "<group>"; };
+		555F2DC217678A9700E84674 /* FKFlickrPeopleGetPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetPhotos.m; sourceTree = "<group>"; };
+		555F2DC317678A9700E84674 /* FKFlickrPeopleGetPhotosOf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetPhotosOf.h; sourceTree = "<group>"; };
+		555F2DC417678A9700E84674 /* FKFlickrPeopleGetPhotosOf.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetPhotosOf.m; sourceTree = "<group>"; };
+		555F2DC517678A9700E84674 /* FKFlickrPeopleGetPublicGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetPublicGroups.h; sourceTree = "<group>"; };
+		555F2DC617678A9700E84674 /* FKFlickrPeopleGetPublicGroups.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetPublicGroups.m; sourceTree = "<group>"; };
+		555F2DC717678A9700E84674 /* FKFlickrPeopleGetPublicPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetPublicPhotos.h; sourceTree = "<group>"; };
+		555F2DC817678A9700E84674 /* FKFlickrPeopleGetPublicPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetPublicPhotos.m; sourceTree = "<group>"; };
+		555F2DC917678A9700E84674 /* FKFlickrPeopleGetUploadStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPeopleGetUploadStatus.h; sourceTree = "<group>"; };
+		555F2DCA17678A9700E84674 /* FKFlickrPeopleGetUploadStatus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPeopleGetUploadStatus.m; sourceTree = "<group>"; };
+		555F2DCD17678A9700E84674 /* FKFlickrPhotosCommentsAddComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosCommentsAddComment.h; sourceTree = "<group>"; };
+		555F2DCE17678A9700E84674 /* FKFlickrPhotosCommentsAddComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosCommentsAddComment.m; sourceTree = "<group>"; };
+		555F2DCF17678A9700E84674 /* FKFlickrPhotosCommentsDeleteComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosCommentsDeleteComment.h; sourceTree = "<group>"; };
+		555F2DD017678A9700E84674 /* FKFlickrPhotosCommentsDeleteComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosCommentsDeleteComment.m; sourceTree = "<group>"; };
+		555F2DD117678A9700E84674 /* FKFlickrPhotosCommentsEditComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosCommentsEditComment.h; sourceTree = "<group>"; };
+		555F2DD217678A9700E84674 /* FKFlickrPhotosCommentsEditComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosCommentsEditComment.m; sourceTree = "<group>"; };
+		555F2DD317678A9700E84674 /* FKFlickrPhotosCommentsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosCommentsGetList.h; sourceTree = "<group>"; };
+		555F2DD417678A9700E84674 /* FKFlickrPhotosCommentsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosCommentsGetList.m; sourceTree = "<group>"; };
+		555F2DD517678A9700E84674 /* FKFlickrPhotosCommentsGetRecentForContacts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosCommentsGetRecentForContacts.h; sourceTree = "<group>"; };
+		555F2DD617678A9700E84674 /* FKFlickrPhotosCommentsGetRecentForContacts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosCommentsGetRecentForContacts.m; sourceTree = "<group>"; };
+		555F2DD717678A9700E84674 /* FKFlickrPhotosAddTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosAddTags.h; sourceTree = "<group>"; };
+		555F2DD817678A9700E84674 /* FKFlickrPhotosAddTags.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosAddTags.m; sourceTree = "<group>"; };
+		555F2DD917678A9700E84674 /* FKFlickrPhotosDelete.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosDelete.h; sourceTree = "<group>"; };
+		555F2DDA17678A9700E84674 /* FKFlickrPhotosDelete.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosDelete.m; sourceTree = "<group>"; };
+		555F2DDB17678A9700E84674 /* FKFlickrPhotosGetAllContexts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetAllContexts.h; sourceTree = "<group>"; };
+		555F2DDC17678A9700E84674 /* FKFlickrPhotosGetAllContexts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetAllContexts.m; sourceTree = "<group>"; };
+		555F2DDD17678A9700E84674 /* FKFlickrPhotosGetContactsPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetContactsPhotos.h; sourceTree = "<group>"; };
+		555F2DDE17678A9700E84674 /* FKFlickrPhotosGetContactsPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetContactsPhotos.m; sourceTree = "<group>"; };
+		555F2DDF17678A9700E84674 /* FKFlickrPhotosGetContactsPublicPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetContactsPublicPhotos.h; sourceTree = "<group>"; };
+		555F2DE017678A9700E84674 /* FKFlickrPhotosGetContactsPublicPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetContactsPublicPhotos.m; sourceTree = "<group>"; };
+		555F2DE117678A9700E84674 /* FKFlickrPhotosGetContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetContext.h; sourceTree = "<group>"; };
+		555F2DE217678A9700E84674 /* FKFlickrPhotosGetContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetContext.m; sourceTree = "<group>"; };
+		555F2DE317678A9700E84674 /* FKFlickrPhotosGetCounts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetCounts.h; sourceTree = "<group>"; };
+		555F2DE417678A9700E84674 /* FKFlickrPhotosGetCounts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetCounts.m; sourceTree = "<group>"; };
+		555F2DE517678A9700E84674 /* FKFlickrPhotosGetExif.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetExif.h; sourceTree = "<group>"; };
+		555F2DE617678A9700E84674 /* FKFlickrPhotosGetExif.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetExif.m; sourceTree = "<group>"; };
+		555F2DE717678A9700E84674 /* FKFlickrPhotosGetFavorites.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetFavorites.h; sourceTree = "<group>"; };
+		555F2DE817678A9700E84674 /* FKFlickrPhotosGetFavorites.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetFavorites.m; sourceTree = "<group>"; };
+		555F2DE917678A9700E84674 /* FKFlickrPhotosGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetInfo.h; sourceTree = "<group>"; };
+		555F2DEA17678A9700E84674 /* FKFlickrPhotosGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetInfo.m; sourceTree = "<group>"; };
+		555F2DEB17678A9700E84674 /* FKFlickrPhotosGetNotInSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetNotInSet.h; sourceTree = "<group>"; };
+		555F2DEC17678A9700E84674 /* FKFlickrPhotosGetNotInSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetNotInSet.m; sourceTree = "<group>"; };
+		555F2DED17678A9700E84674 /* FKFlickrPhotosGetPerms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetPerms.h; sourceTree = "<group>"; };
+		555F2DEE17678A9700E84674 /* FKFlickrPhotosGetPerms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetPerms.m; sourceTree = "<group>"; };
+		555F2DEF17678A9700E84674 /* FKFlickrPhotosGetRecent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetRecent.h; sourceTree = "<group>"; };
+		555F2DF017678A9700E84674 /* FKFlickrPhotosGetRecent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetRecent.m; sourceTree = "<group>"; };
+		555F2DF117678A9700E84674 /* FKFlickrPhotosGetSizes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetSizes.h; sourceTree = "<group>"; };
+		555F2DF217678A9700E84674 /* FKFlickrPhotosGetSizes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetSizes.m; sourceTree = "<group>"; };
+		555F2DF317678A9700E84674 /* FKFlickrPhotosGetUntagged.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetUntagged.h; sourceTree = "<group>"; };
+		555F2DF417678A9700E84674 /* FKFlickrPhotosGetUntagged.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetUntagged.m; sourceTree = "<group>"; };
+		555F2DF517678A9700E84674 /* FKFlickrPhotosGetWithGeoData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetWithGeoData.h; sourceTree = "<group>"; };
+		555F2DF617678A9700E84674 /* FKFlickrPhotosGetWithGeoData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetWithGeoData.m; sourceTree = "<group>"; };
+		555F2DF717678A9700E84674 /* FKFlickrPhotosGetWithoutGeoData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGetWithoutGeoData.h; sourceTree = "<group>"; };
+		555F2DF817678A9700E84674 /* FKFlickrPhotosGetWithoutGeoData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGetWithoutGeoData.m; sourceTree = "<group>"; };
+		555F2DF917678A9700E84674 /* FKFlickrPhotosRecentlyUpdated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosRecentlyUpdated.h; sourceTree = "<group>"; };
+		555F2DFA17678A9700E84674 /* FKFlickrPhotosRecentlyUpdated.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosRecentlyUpdated.m; sourceTree = "<group>"; };
+		555F2DFB17678A9700E84674 /* FKFlickrPhotosRemoveTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosRemoveTag.h; sourceTree = "<group>"; };
+		555F2DFC17678A9700E84674 /* FKFlickrPhotosRemoveTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosRemoveTag.m; sourceTree = "<group>"; };
+		555F2DFD17678A9700E84674 /* FKFlickrPhotosSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSearch.h; sourceTree = "<group>"; };
+		555F2DFE17678A9700E84674 /* FKFlickrPhotosSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSearch.m; sourceTree = "<group>"; };
+		555F2DFF17678A9700E84674 /* FKFlickrPhotosSetContentType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSetContentType.h; sourceTree = "<group>"; };
+		555F2E0017678A9700E84674 /* FKFlickrPhotosSetContentType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSetContentType.m; sourceTree = "<group>"; };
+		555F2E0117678A9700E84674 /* FKFlickrPhotosSetDates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSetDates.h; sourceTree = "<group>"; };
+		555F2E0217678A9700E84674 /* FKFlickrPhotosSetDates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSetDates.m; sourceTree = "<group>"; };
+		555F2E0317678A9700E84674 /* FKFlickrPhotosSetMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSetMeta.h; sourceTree = "<group>"; };
+		555F2E0417678A9700E84674 /* FKFlickrPhotosSetMeta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSetMeta.m; sourceTree = "<group>"; };
+		555F2E0517678A9700E84674 /* FKFlickrPhotosSetPerms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSetPerms.h; sourceTree = "<group>"; };
+		555F2E0617678A9700E84674 /* FKFlickrPhotosSetPerms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSetPerms.m; sourceTree = "<group>"; };
+		555F2E0717678A9700E84674 /* FKFlickrPhotosSetSafetyLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSetSafetyLevel.h; sourceTree = "<group>"; };
+		555F2E0817678A9700E84674 /* FKFlickrPhotosSetSafetyLevel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSetSafetyLevel.m; sourceTree = "<group>"; };
+		555F2E0917678A9700E84674 /* FKFlickrPhotosSetTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSetTags.h; sourceTree = "<group>"; };
+		555F2E0A17678A9700E84674 /* FKFlickrPhotosSetTags.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSetTags.m; sourceTree = "<group>"; };
+		555F2E0D17678A9700E84674 /* FKFlickrPhotosGeoBatchCorrectLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoBatchCorrectLocation.h; sourceTree = "<group>"; };
+		555F2E0E17678A9700E84674 /* FKFlickrPhotosGeoBatchCorrectLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoBatchCorrectLocation.m; sourceTree = "<group>"; };
+		555F2E0F17678A9700E84674 /* FKFlickrPhotosGeoCorrectLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoCorrectLocation.h; sourceTree = "<group>"; };
+		555F2E1017678A9700E84674 /* FKFlickrPhotosGeoCorrectLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoCorrectLocation.m; sourceTree = "<group>"; };
+		555F2E1117678A9700E84674 /* FKFlickrPhotosGeoGetLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoGetLocation.h; sourceTree = "<group>"; };
+		555F2E1217678A9700E84674 /* FKFlickrPhotosGeoGetLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoGetLocation.m; sourceTree = "<group>"; };
+		555F2E1317678A9700E84674 /* FKFlickrPhotosGeoGetPerms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoGetPerms.h; sourceTree = "<group>"; };
+		555F2E1417678A9700E84674 /* FKFlickrPhotosGeoGetPerms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoGetPerms.m; sourceTree = "<group>"; };
+		555F2E1517678A9700E84674 /* FKFlickrPhotosGeoPhotosForLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoPhotosForLocation.h; sourceTree = "<group>"; };
+		555F2E1617678A9700E84674 /* FKFlickrPhotosGeoPhotosForLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoPhotosForLocation.m; sourceTree = "<group>"; };
+		555F2E1717678A9700E84674 /* FKFlickrPhotosGeoRemoveLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoRemoveLocation.h; sourceTree = "<group>"; };
+		555F2E1817678A9700E84674 /* FKFlickrPhotosGeoRemoveLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoRemoveLocation.m; sourceTree = "<group>"; };
+		555F2E1917678A9700E84674 /* FKFlickrPhotosGeoSetContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoSetContext.h; sourceTree = "<group>"; };
+		555F2E1A17678A9700E84674 /* FKFlickrPhotosGeoSetContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoSetContext.m; sourceTree = "<group>"; };
+		555F2E1B17678A9700E84674 /* FKFlickrPhotosGeoSetLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoSetLocation.h; sourceTree = "<group>"; };
+		555F2E1C17678A9700E84674 /* FKFlickrPhotosGeoSetLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoSetLocation.m; sourceTree = "<group>"; };
+		555F2E1D17678A9700E84674 /* FKFlickrPhotosGeoSetPerms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosGeoSetPerms.h; sourceTree = "<group>"; };
+		555F2E1E17678A9700E84674 /* FKFlickrPhotosGeoSetPerms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosGeoSetPerms.m; sourceTree = "<group>"; };
+		555F2E2017678A9700E84674 /* FKFlickrPhotosLicensesGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosLicensesGetInfo.h; sourceTree = "<group>"; };
+		555F2E2117678A9700E84674 /* FKFlickrPhotosLicensesGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosLicensesGetInfo.m; sourceTree = "<group>"; };
+		555F2E2217678A9700E84674 /* FKFlickrPhotosLicensesSetLicense.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosLicensesSetLicense.h; sourceTree = "<group>"; };
+		555F2E2317678A9700E84674 /* FKFlickrPhotosLicensesSetLicense.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosLicensesSetLicense.m; sourceTree = "<group>"; };
+		555F2E2517678A9700E84674 /* FKFlickrPhotosNotesAdd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosNotesAdd.h; sourceTree = "<group>"; };
+		555F2E2617678A9700E84674 /* FKFlickrPhotosNotesAdd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosNotesAdd.m; sourceTree = "<group>"; };
+		555F2E2717678A9700E84674 /* FKFlickrPhotosNotesDelete.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosNotesDelete.h; sourceTree = "<group>"; };
+		555F2E2817678A9700E84674 /* FKFlickrPhotosNotesDelete.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosNotesDelete.m; sourceTree = "<group>"; };
+		555F2E2917678A9700E84674 /* FKFlickrPhotosNotesEdit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosNotesEdit.h; sourceTree = "<group>"; };
+		555F2E2A17678A9700E84674 /* FKFlickrPhotosNotesEdit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosNotesEdit.m; sourceTree = "<group>"; };
+		555F2E2C17678A9700E84674 /* FKFlickrPhotosPeopleAdd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosPeopleAdd.h; sourceTree = "<group>"; };
+		555F2E2D17678A9700E84674 /* FKFlickrPhotosPeopleAdd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosPeopleAdd.m; sourceTree = "<group>"; };
+		555F2E2E17678A9700E84674 /* FKFlickrPhotosPeopleDelete.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosPeopleDelete.h; sourceTree = "<group>"; };
+		555F2E2F17678A9700E84674 /* FKFlickrPhotosPeopleDelete.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosPeopleDelete.m; sourceTree = "<group>"; };
+		555F2E3017678A9700E84674 /* FKFlickrPhotosPeopleDeleteCoords.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosPeopleDeleteCoords.h; sourceTree = "<group>"; };
+		555F2E3117678A9700E84674 /* FKFlickrPhotosPeopleDeleteCoords.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosPeopleDeleteCoords.m; sourceTree = "<group>"; };
+		555F2E3217678A9700E84674 /* FKFlickrPhotosPeopleEditCoords.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosPeopleEditCoords.h; sourceTree = "<group>"; };
+		555F2E3317678A9700E84674 /* FKFlickrPhotosPeopleEditCoords.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosPeopleEditCoords.m; sourceTree = "<group>"; };
+		555F2E3417678A9700E84674 /* FKFlickrPhotosPeopleGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosPeopleGetList.h; sourceTree = "<group>"; };
+		555F2E3517678A9700E84674 /* FKFlickrPhotosPeopleGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosPeopleGetList.m; sourceTree = "<group>"; };
+		555F2E3717678A9700E84674 /* FKFlickrPhotosSuggestionsApproveSuggestion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSuggestionsApproveSuggestion.h; sourceTree = "<group>"; };
+		555F2E3817678A9700E84674 /* FKFlickrPhotosSuggestionsApproveSuggestion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSuggestionsApproveSuggestion.m; sourceTree = "<group>"; };
+		555F2E3917678A9700E84674 /* FKFlickrPhotosSuggestionsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSuggestionsGetList.h; sourceTree = "<group>"; };
+		555F2E3A17678A9700E84674 /* FKFlickrPhotosSuggestionsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSuggestionsGetList.m; sourceTree = "<group>"; };
+		555F2E3B17678A9700E84674 /* FKFlickrPhotosSuggestionsRejectSuggestion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSuggestionsRejectSuggestion.h; sourceTree = "<group>"; };
+		555F2E3C17678A9700E84674 /* FKFlickrPhotosSuggestionsRejectSuggestion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSuggestionsRejectSuggestion.m; sourceTree = "<group>"; };
+		555F2E3D17678A9700E84674 /* FKFlickrPhotosSuggestionsRemoveSuggestion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSuggestionsRemoveSuggestion.h; sourceTree = "<group>"; };
+		555F2E3E17678A9700E84674 /* FKFlickrPhotosSuggestionsRemoveSuggestion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSuggestionsRemoveSuggestion.m; sourceTree = "<group>"; };
+		555F2E3F17678A9700E84674 /* FKFlickrPhotosSuggestionsSuggestLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosSuggestionsSuggestLocation.h; sourceTree = "<group>"; };
+		555F2E4017678A9700E84674 /* FKFlickrPhotosSuggestionsSuggestLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosSuggestionsSuggestLocation.m; sourceTree = "<group>"; };
+		555F2E4217678A9700E84674 /* FKFlickrPhotosTransformRotate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosTransformRotate.h; sourceTree = "<group>"; };
+		555F2E4317678A9700E84674 /* FKFlickrPhotosTransformRotate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosTransformRotate.m; sourceTree = "<group>"; };
+		555F2E4517678A9700E84674 /* FKFlickrPhotosUploadCheckTickets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosUploadCheckTickets.h; sourceTree = "<group>"; };
+		555F2E4617678A9700E84674 /* FKFlickrPhotosUploadCheckTickets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosUploadCheckTickets.m; sourceTree = "<group>"; };
+		555F2E4917678A9700E84674 /* FKFlickrPhotosetsCommentsAddComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsCommentsAddComment.h; sourceTree = "<group>"; };
+		555F2E4A17678A9700E84674 /* FKFlickrPhotosetsCommentsAddComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsCommentsAddComment.m; sourceTree = "<group>"; };
+		555F2E4B17678A9700E84674 /* FKFlickrPhotosetsCommentsDeleteComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsCommentsDeleteComment.h; sourceTree = "<group>"; };
+		555F2E4C17678A9700E84674 /* FKFlickrPhotosetsCommentsDeleteComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsCommentsDeleteComment.m; sourceTree = "<group>"; };
+		555F2E4D17678A9700E84674 /* FKFlickrPhotosetsCommentsEditComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsCommentsEditComment.h; sourceTree = "<group>"; };
+		555F2E4E17678A9700E84674 /* FKFlickrPhotosetsCommentsEditComment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsCommentsEditComment.m; sourceTree = "<group>"; };
+		555F2E4F17678A9700E84674 /* FKFlickrPhotosetsCommentsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsCommentsGetList.h; sourceTree = "<group>"; };
+		555F2E5017678A9700E84674 /* FKFlickrPhotosetsCommentsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsCommentsGetList.m; sourceTree = "<group>"; };
+		555F2E5117678A9700E84674 /* FKFlickrPhotosetsAddPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsAddPhoto.h; sourceTree = "<group>"; };
+		555F2E5217678A9700E84674 /* FKFlickrPhotosetsAddPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsAddPhoto.m; sourceTree = "<group>"; };
+		555F2E5317678A9700E84674 /* FKFlickrPhotosetsCreate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsCreate.h; sourceTree = "<group>"; };
+		555F2E5417678A9700E84674 /* FKFlickrPhotosetsCreate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsCreate.m; sourceTree = "<group>"; };
+		555F2E5517678A9700E84674 /* FKFlickrPhotosetsDelete.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsDelete.h; sourceTree = "<group>"; };
+		555F2E5617678A9700E84674 /* FKFlickrPhotosetsDelete.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsDelete.m; sourceTree = "<group>"; };
+		555F2E5717678A9700E84674 /* FKFlickrPhotosetsEditMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsEditMeta.h; sourceTree = "<group>"; };
+		555F2E5817678A9700E84674 /* FKFlickrPhotosetsEditMeta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsEditMeta.m; sourceTree = "<group>"; };
+		555F2E5917678A9700E84674 /* FKFlickrPhotosetsEditPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsEditPhotos.h; sourceTree = "<group>"; };
+		555F2E5A17678A9700E84674 /* FKFlickrPhotosetsEditPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsEditPhotos.m; sourceTree = "<group>"; };
+		555F2E5B17678A9700E84674 /* FKFlickrPhotosetsGetContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsGetContext.h; sourceTree = "<group>"; };
+		555F2E5C17678A9700E84674 /* FKFlickrPhotosetsGetContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsGetContext.m; sourceTree = "<group>"; };
+		555F2E5D17678A9700E84674 /* FKFlickrPhotosetsGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsGetInfo.h; sourceTree = "<group>"; };
+		555F2E5E17678A9700E84674 /* FKFlickrPhotosetsGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsGetInfo.m; sourceTree = "<group>"; };
+		555F2E5F17678A9700E84674 /* FKFlickrPhotosetsGetList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsGetList.h; sourceTree = "<group>"; };
+		555F2E6017678A9700E84674 /* FKFlickrPhotosetsGetList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsGetList.m; sourceTree = "<group>"; };
+		555F2E6117678A9700E84674 /* FKFlickrPhotosetsGetPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsGetPhotos.h; sourceTree = "<group>"; };
+		555F2E6217678A9700E84674 /* FKFlickrPhotosetsGetPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsGetPhotos.m; sourceTree = "<group>"; };
+		555F2E6317678A9700E84674 /* FKFlickrPhotosetsOrderSets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsOrderSets.h; sourceTree = "<group>"; };
+		555F2E6417678A9700E84674 /* FKFlickrPhotosetsOrderSets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsOrderSets.m; sourceTree = "<group>"; };
+		555F2E6517678A9700E84674 /* FKFlickrPhotosetsRemovePhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsRemovePhoto.h; sourceTree = "<group>"; };
+		555F2E6617678A9700E84674 /* FKFlickrPhotosetsRemovePhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsRemovePhoto.m; sourceTree = "<group>"; };
+		555F2E6717678A9700E84674 /* FKFlickrPhotosetsRemovePhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsRemovePhotos.h; sourceTree = "<group>"; };
+		555F2E6817678A9700E84674 /* FKFlickrPhotosetsRemovePhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsRemovePhotos.m; sourceTree = "<group>"; };
+		555F2E6917678A9700E84674 /* FKFlickrPhotosetsReorderPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsReorderPhotos.h; sourceTree = "<group>"; };
+		555F2E6A17678A9700E84674 /* FKFlickrPhotosetsReorderPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsReorderPhotos.m; sourceTree = "<group>"; };
+		555F2E6B17678A9700E84674 /* FKFlickrPhotosetsSetPrimaryPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPhotosetsSetPrimaryPhoto.h; sourceTree = "<group>"; };
+		555F2E6C17678A9700E84674 /* FKFlickrPhotosetsSetPrimaryPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPhotosetsSetPrimaryPhoto.m; sourceTree = "<group>"; };
+		555F2E6E17678A9700E84674 /* FKFlickrPlacesFind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesFind.h; sourceTree = "<group>"; };
+		555F2E6F17678A9700E84674 /* FKFlickrPlacesFind.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesFind.m; sourceTree = "<group>"; };
+		555F2E7017678A9700E84674 /* FKFlickrPlacesFindByLatLon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesFindByLatLon.h; sourceTree = "<group>"; };
+		555F2E7117678A9700E84674 /* FKFlickrPlacesFindByLatLon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesFindByLatLon.m; sourceTree = "<group>"; };
+		555F2E7217678A9700E84674 /* FKFlickrPlacesGetChildrenWithPhotosPublic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesGetChildrenWithPhotosPublic.h; sourceTree = "<group>"; };
+		555F2E7317678A9700E84674 /* FKFlickrPlacesGetChildrenWithPhotosPublic.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesGetChildrenWithPhotosPublic.m; sourceTree = "<group>"; };
+		555F2E7417678A9700E84674 /* FKFlickrPlacesGetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesGetInfo.h; sourceTree = "<group>"; };
+		555F2E7517678A9700E84674 /* FKFlickrPlacesGetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesGetInfo.m; sourceTree = "<group>"; };
+		555F2E7617678A9700E84674 /* FKFlickrPlacesGetInfoByUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesGetInfoByUrl.h; sourceTree = "<group>"; };
+		555F2E7717678A9700E84674 /* FKFlickrPlacesGetInfoByUrl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesGetInfoByUrl.m; sourceTree = "<group>"; };
+		555F2E7817678A9700E84674 /* FKFlickrPlacesGetPlaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesGetPlaceTypes.h; sourceTree = "<group>"; };
+		555F2E7917678A9700E84674 /* FKFlickrPlacesGetPlaceTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesGetPlaceTypes.m; sourceTree = "<group>"; };
+		555F2E7A17678A9700E84674 /* FKFlickrPlacesGetShapeHistory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesGetShapeHistory.h; sourceTree = "<group>"; };
+		555F2E7B17678A9700E84674 /* FKFlickrPlacesGetShapeHistory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesGetShapeHistory.m; sourceTree = "<group>"; };
+		555F2E7C17678A9700E84674 /* FKFlickrPlacesGetTopPlacesList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesGetTopPlacesList.h; sourceTree = "<group>"; };
+		555F2E7D17678A9700E84674 /* FKFlickrPlacesGetTopPlacesList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesGetTopPlacesList.m; sourceTree = "<group>"; };
+		555F2E7E17678A9700E84674 /* FKFlickrPlacesPlacesForBoundingBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesPlacesForBoundingBox.h; sourceTree = "<group>"; };
+		555F2E7F17678A9700E84674 /* FKFlickrPlacesPlacesForBoundingBox.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesPlacesForBoundingBox.m; sourceTree = "<group>"; };
+		555F2E8017678A9700E84674 /* FKFlickrPlacesPlacesForContacts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesPlacesForContacts.h; sourceTree = "<group>"; };
+		555F2E8117678A9700E84674 /* FKFlickrPlacesPlacesForContacts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesPlacesForContacts.m; sourceTree = "<group>"; };
+		555F2E8217678A9700E84674 /* FKFlickrPlacesPlacesForTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesPlacesForTags.h; sourceTree = "<group>"; };
+		555F2E8317678A9700E84674 /* FKFlickrPlacesPlacesForTags.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesPlacesForTags.m; sourceTree = "<group>"; };
+		555F2E8417678A9800E84674 /* FKFlickrPlacesPlacesForUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesPlacesForUser.h; sourceTree = "<group>"; };
+		555F2E8517678A9800E84674 /* FKFlickrPlacesPlacesForUser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesPlacesForUser.m; sourceTree = "<group>"; };
+		555F2E8617678A9800E84674 /* FKFlickrPlacesResolvePlaceId.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesResolvePlaceId.h; sourceTree = "<group>"; };
+		555F2E8717678A9800E84674 /* FKFlickrPlacesResolvePlaceId.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesResolvePlaceId.m; sourceTree = "<group>"; };
+		555F2E8817678A9800E84674 /* FKFlickrPlacesResolvePlaceURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesResolvePlaceURL.h; sourceTree = "<group>"; };
+		555F2E8917678A9800E84674 /* FKFlickrPlacesResolvePlaceURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesResolvePlaceURL.m; sourceTree = "<group>"; };
+		555F2E8A17678A9800E84674 /* FKFlickrPlacesTagsForPlace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPlacesTagsForPlace.h; sourceTree = "<group>"; };
+		555F2E8B17678A9800E84674 /* FKFlickrPlacesTagsForPlace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPlacesTagsForPlace.m; sourceTree = "<group>"; };
+		555F2E8D17678A9800E84674 /* FKFlickrPrefsGetContentType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPrefsGetContentType.h; sourceTree = "<group>"; };
+		555F2E8E17678A9800E84674 /* FKFlickrPrefsGetContentType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPrefsGetContentType.m; sourceTree = "<group>"; };
+		555F2E8F17678A9800E84674 /* FKFlickrPrefsGetGeoPerms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPrefsGetGeoPerms.h; sourceTree = "<group>"; };
+		555F2E9017678A9800E84674 /* FKFlickrPrefsGetGeoPerms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPrefsGetGeoPerms.m; sourceTree = "<group>"; };
+		555F2E9117678A9800E84674 /* FKFlickrPrefsGetHidden.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPrefsGetHidden.h; sourceTree = "<group>"; };
+		555F2E9217678A9800E84674 /* FKFlickrPrefsGetHidden.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPrefsGetHidden.m; sourceTree = "<group>"; };
+		555F2E9317678A9800E84674 /* FKFlickrPrefsGetPrivacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPrefsGetPrivacy.h; sourceTree = "<group>"; };
+		555F2E9417678A9800E84674 /* FKFlickrPrefsGetPrivacy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPrefsGetPrivacy.m; sourceTree = "<group>"; };
+		555F2E9517678A9800E84674 /* FKFlickrPrefsGetSafetyLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPrefsGetSafetyLevel.h; sourceTree = "<group>"; };
+		555F2E9617678A9800E84674 /* FKFlickrPrefsGetSafetyLevel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPrefsGetSafetyLevel.m; sourceTree = "<group>"; };
+		555F2E9817678A9800E84674 /* FKFlickrPushGetSubscriptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPushGetSubscriptions.h; sourceTree = "<group>"; };
+		555F2E9917678A9800E84674 /* FKFlickrPushGetSubscriptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPushGetSubscriptions.m; sourceTree = "<group>"; };
+		555F2E9A17678A9800E84674 /* FKFlickrPushGetTopics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPushGetTopics.h; sourceTree = "<group>"; };
+		555F2E9B17678A9800E84674 /* FKFlickrPushGetTopics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPushGetTopics.m; sourceTree = "<group>"; };
+		555F2E9C17678A9800E84674 /* FKFlickrPushSubscribe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPushSubscribe.h; sourceTree = "<group>"; };
+		555F2E9D17678A9800E84674 /* FKFlickrPushSubscribe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPushSubscribe.m; sourceTree = "<group>"; };
+		555F2E9E17678A9800E84674 /* FKFlickrPushUnsubscribe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrPushUnsubscribe.h; sourceTree = "<group>"; };
+		555F2E9F17678A9800E84674 /* FKFlickrPushUnsubscribe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrPushUnsubscribe.m; sourceTree = "<group>"; };
+		555F2EA117678A9800E84674 /* FKFlickrReflectionGetMethodInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrReflectionGetMethodInfo.h; sourceTree = "<group>"; };
+		555F2EA217678A9800E84674 /* FKFlickrReflectionGetMethodInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrReflectionGetMethodInfo.m; sourceTree = "<group>"; };
+		555F2EA317678A9800E84674 /* FKFlickrReflectionGetMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrReflectionGetMethods.h; sourceTree = "<group>"; };
+		555F2EA417678A9800E84674 /* FKFlickrReflectionGetMethods.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrReflectionGetMethods.m; sourceTree = "<group>"; };
+		555F2EA617678A9800E84674 /* FKFlickrStatsGetCollectionDomains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetCollectionDomains.h; sourceTree = "<group>"; };
+		555F2EA717678A9800E84674 /* FKFlickrStatsGetCollectionDomains.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetCollectionDomains.m; sourceTree = "<group>"; };
+		555F2EA817678A9800E84674 /* FKFlickrStatsGetCollectionReferrers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetCollectionReferrers.h; sourceTree = "<group>"; };
+		555F2EA917678A9800E84674 /* FKFlickrStatsGetCollectionReferrers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetCollectionReferrers.m; sourceTree = "<group>"; };
+		555F2EAA17678A9800E84674 /* FKFlickrStatsGetCollectionStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetCollectionStats.h; sourceTree = "<group>"; };
+		555F2EAB17678A9800E84674 /* FKFlickrStatsGetCollectionStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetCollectionStats.m; sourceTree = "<group>"; };
+		555F2EAC17678A9800E84674 /* FKFlickrStatsGetCSVFiles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetCSVFiles.h; sourceTree = "<group>"; };
+		555F2EAD17678A9800E84674 /* FKFlickrStatsGetCSVFiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetCSVFiles.m; sourceTree = "<group>"; };
+		555F2EAE17678A9800E84674 /* FKFlickrStatsGetPhotoDomains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotoDomains.h; sourceTree = "<group>"; };
+		555F2EAF17678A9800E84674 /* FKFlickrStatsGetPhotoDomains.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotoDomains.m; sourceTree = "<group>"; };
+		555F2EB017678A9800E84674 /* FKFlickrStatsGetPhotoReferrers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotoReferrers.h; sourceTree = "<group>"; };
+		555F2EB117678A9800E84674 /* FKFlickrStatsGetPhotoReferrers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotoReferrers.m; sourceTree = "<group>"; };
+		555F2EB217678A9800E84674 /* FKFlickrStatsGetPhotosetDomains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotosetDomains.h; sourceTree = "<group>"; };
+		555F2EB317678A9800E84674 /* FKFlickrStatsGetPhotosetDomains.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotosetDomains.m; sourceTree = "<group>"; };
+		555F2EB417678A9800E84674 /* FKFlickrStatsGetPhotosetReferrers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotosetReferrers.h; sourceTree = "<group>"; };
+		555F2EB517678A9800E84674 /* FKFlickrStatsGetPhotosetReferrers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotosetReferrers.m; sourceTree = "<group>"; };
+		555F2EB617678A9800E84674 /* FKFlickrStatsGetPhotosetStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotosetStats.h; sourceTree = "<group>"; };
+		555F2EB717678A9800E84674 /* FKFlickrStatsGetPhotosetStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotosetStats.m; sourceTree = "<group>"; };
+		555F2EB817678A9800E84674 /* FKFlickrStatsGetPhotoStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotoStats.h; sourceTree = "<group>"; };
+		555F2EB917678A9800E84674 /* FKFlickrStatsGetPhotoStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotoStats.m; sourceTree = "<group>"; };
+		555F2EBA17678A9800E84674 /* FKFlickrStatsGetPhotostreamDomains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotostreamDomains.h; sourceTree = "<group>"; };
+		555F2EBB17678A9800E84674 /* FKFlickrStatsGetPhotostreamDomains.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotostreamDomains.m; sourceTree = "<group>"; };
+		555F2EBC17678A9800E84674 /* FKFlickrStatsGetPhotostreamReferrers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotostreamReferrers.h; sourceTree = "<group>"; };
+		555F2EBD17678A9800E84674 /* FKFlickrStatsGetPhotostreamReferrers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotostreamReferrers.m; sourceTree = "<group>"; };
+		555F2EBE17678A9800E84674 /* FKFlickrStatsGetPhotostreamStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPhotostreamStats.h; sourceTree = "<group>"; };
+		555F2EBF17678A9800E84674 /* FKFlickrStatsGetPhotostreamStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPhotostreamStats.m; sourceTree = "<group>"; };
+		555F2EC017678A9800E84674 /* FKFlickrStatsGetPopularPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetPopularPhotos.h; sourceTree = "<group>"; };
+		555F2EC117678A9800E84674 /* FKFlickrStatsGetPopularPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetPopularPhotos.m; sourceTree = "<group>"; };
+		555F2EC217678A9800E84674 /* FKFlickrStatsGetTotalViews.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrStatsGetTotalViews.h; sourceTree = "<group>"; };
+		555F2EC317678A9800E84674 /* FKFlickrStatsGetTotalViews.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrStatsGetTotalViews.m; sourceTree = "<group>"; };
+		555F2EC517678A9800E84674 /* FKFlickrTagsGetClusterPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetClusterPhotos.h; sourceTree = "<group>"; };
+		555F2EC617678A9800E84674 /* FKFlickrTagsGetClusterPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetClusterPhotos.m; sourceTree = "<group>"; };
+		555F2EC717678A9800E84674 /* FKFlickrTagsGetClusters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetClusters.h; sourceTree = "<group>"; };
+		555F2EC817678A9800E84674 /* FKFlickrTagsGetClusters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetClusters.m; sourceTree = "<group>"; };
+		555F2EC917678A9800E84674 /* FKFlickrTagsGetHotList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetHotList.h; sourceTree = "<group>"; };
+		555F2ECA17678A9800E84674 /* FKFlickrTagsGetHotList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetHotList.m; sourceTree = "<group>"; };
+		555F2ECB17678A9800E84674 /* FKFlickrTagsGetListPhoto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetListPhoto.h; sourceTree = "<group>"; };
+		555F2ECC17678A9800E84674 /* FKFlickrTagsGetListPhoto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetListPhoto.m; sourceTree = "<group>"; };
+		555F2ECD17678A9800E84674 /* FKFlickrTagsGetListUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetListUser.h; sourceTree = "<group>"; };
+		555F2ECE17678A9800E84674 /* FKFlickrTagsGetListUser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetListUser.m; sourceTree = "<group>"; };
+		555F2ECF17678A9800E84674 /* FKFlickrTagsGetListUserPopular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetListUserPopular.h; sourceTree = "<group>"; };
+		555F2ED017678A9800E84674 /* FKFlickrTagsGetListUserPopular.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetListUserPopular.m; sourceTree = "<group>"; };
+		555F2ED117678A9800E84674 /* FKFlickrTagsGetListUserRaw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetListUserRaw.h; sourceTree = "<group>"; };
+		555F2ED217678A9800E84674 /* FKFlickrTagsGetListUserRaw.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetListUserRaw.m; sourceTree = "<group>"; };
+		555F2ED317678A9800E84674 /* FKFlickrTagsGetMostFrequentlyUsed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetMostFrequentlyUsed.h; sourceTree = "<group>"; };
+		555F2ED417678A9800E84674 /* FKFlickrTagsGetMostFrequentlyUsed.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetMostFrequentlyUsed.m; sourceTree = "<group>"; };
+		555F2ED517678A9800E84674 /* FKFlickrTagsGetRelated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTagsGetRelated.h; sourceTree = "<group>"; };
+		555F2ED617678A9800E84674 /* FKFlickrTagsGetRelated.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTagsGetRelated.m; sourceTree = "<group>"; };
+		555F2ED817678A9800E84674 /* FKFlickrTestEcho.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTestEcho.h; sourceTree = "<group>"; };
+		555F2ED917678A9800E84674 /* FKFlickrTestEcho.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTestEcho.m; sourceTree = "<group>"; };
+		555F2EDA17678A9800E84674 /* FKFlickrTestLogin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTestLogin.h; sourceTree = "<group>"; };
+		555F2EDB17678A9800E84674 /* FKFlickrTestLogin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTestLogin.m; sourceTree = "<group>"; };
+		555F2EDC17678A9800E84674 /* FKFlickrTestNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrTestNull.h; sourceTree = "<group>"; };
+		555F2EDD17678A9800E84674 /* FKFlickrTestNull.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrTestNull.m; sourceTree = "<group>"; };
+		555F2EDF17678A9800E84674 /* FKFlickrUrlsGetGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrUrlsGetGroup.h; sourceTree = "<group>"; };
+		555F2EE017678A9800E84674 /* FKFlickrUrlsGetGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrUrlsGetGroup.m; sourceTree = "<group>"; };
+		555F2EE117678A9800E84674 /* FKFlickrUrlsGetUserPhotos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrUrlsGetUserPhotos.h; sourceTree = "<group>"; };
+		555F2EE217678A9800E84674 /* FKFlickrUrlsGetUserPhotos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrUrlsGetUserPhotos.m; sourceTree = "<group>"; };
+		555F2EE317678A9800E84674 /* FKFlickrUrlsGetUserProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrUrlsGetUserProfile.h; sourceTree = "<group>"; };
+		555F2EE417678A9800E84674 /* FKFlickrUrlsGetUserProfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrUrlsGetUserProfile.m; sourceTree = "<group>"; };
+		555F2EE517678A9800E84674 /* FKFlickrUrlsLookupGallery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrUrlsLookupGallery.h; sourceTree = "<group>"; };
+		555F2EE617678A9800E84674 /* FKFlickrUrlsLookupGallery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrUrlsLookupGallery.m; sourceTree = "<group>"; };
+		555F2EE717678A9800E84674 /* FKFlickrUrlsLookupGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrUrlsLookupGroup.h; sourceTree = "<group>"; };
+		555F2EE817678A9800E84674 /* FKFlickrUrlsLookupGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrUrlsLookupGroup.m; sourceTree = "<group>"; };
+		555F2EE917678A9800E84674 /* FKFlickrUrlsLookupUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKFlickrUrlsLookupUser.h; sourceTree = "<group>"; };
+		555F2EEA17678A9800E84674 /* FKFlickrUrlsLookupUser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKFlickrUrlsLookupUser.m; sourceTree = "<group>"; };
+		55958DEF1767BD7B0078905C /* FKAPIMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKAPIMethods.h; path = Model/FKAPIMethods.h; sourceTree = "<group>"; };
+		55A5B666176613F900745C71 /* FKDUStreamUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUStreamUtil.h; sourceTree = "<group>"; };
+		55A5B667176613F900745C71 /* FKDUStreamUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUStreamUtil.m; sourceTree = "<group>"; };
+		55AD4849175CA188004AF85C /* FKDataTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKDataTypes.h; path = FlickrKit/FKDataTypes.h; sourceTree = "<group>"; };
+		55AD484A175CA188004AF85C /* FKDataTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FKDataTypes.m; path = FlickrKit/FKDataTypes.m; sourceTree = "<group>"; };
+		55AD48E1175E7561004AF85C /* FlickrKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FlickrKit.m; path = FlickrKit/FlickrKit.m; sourceTree = "<group>"; };
+		55AD48E7175F3217004AF85C /* FKDUNetworkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUNetworkOperation.h; sourceTree = "<group>"; };
+		55AD48E8175F3217004AF85C /* FKDUNetworkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUNetworkOperation.m; sourceTree = "<group>"; };
+		55AD49041760DBE4004AF85C /* FKImageUploadNetworkOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKImageUploadNetworkOperation.h; sourceTree = "<group>"; };
+		55AD49051760DBE5004AF85C /* FKImageUploadNetworkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKImageUploadNetworkOperation.m; sourceTree = "<group>"; };
+		55AD49081760E545004AF85C /* FKUploadRespone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKUploadRespone.h; sourceTree = "<group>"; };
+		55AD49091760E546004AF85C /* FKUploadRespone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKUploadRespone.m; sourceTree = "<group>"; };
+		55AEEF4A175661C100B61A3C /* FlickrKitUtilTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlickrKitUtilTests.h; sourceTree = "<group>"; };
+		55AEEF4B175661C100B61A3C /* FlickrKitUtilTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlickrKitUtilTests.m; sourceTree = "<group>"; };
+		55AEEF4E1756646400B61A3C /* FKUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKUtilities.h; path = Utilities/FKUtilities.h; sourceTree = "<group>"; };
+		55AEEF4F1756646400B61A3C /* FKUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FKUtilities.m; path = Utilities/FKUtilities.m; sourceTree = "<group>"; };
+		55AEEF55175766D500B61A3C /* FKDUReachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FKDUReachability.h; sourceTree = "<group>"; };
+		55AEEF56175766D500B61A3C /* FKDUReachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FKDUReachability.m; sourceTree = "<group>"; };
+		55AEEF59175766EF00B61A3C /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		55B206EA176903DB00A19A12 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
+		55B206EB176903E300A19A12 /* Source Code License.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = "Source Code License.rtf"; sourceTree = "<group>"; };
+		55EA68AB17CAABD40017DDD1 /* FKOFHMACSha1Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKOFHMACSha1Base64.h; path = Utilities/FKOFHMACSha1Base64.h; sourceTree = "<group>"; };
+		55EA68AC17CAABD40017DDD1 /* FKOFHMACSha1Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FKOFHMACSha1Base64.m; path = Utilities/FKOFHMACSha1Base64.m; sourceTree = "<group>"; };
+		5B2B54921831801B00360DAC /* FlickrKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FlickrKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B2B54931831801B00360DAC /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		5B2B54961831801B00360DAC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		5B2B54971831801B00360DAC /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		5B2B54981831801B00360DAC /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		5B2B549B1831801B00360DAC /* FlickrKit-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "FlickrKit-Info.plist"; path = "FlickrKit OS X/FlickrKit-Info.plist"; sourceTree = SOURCE_ROOT; };
+		5B2B549D1831801B00360DAC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		5B2B549F1831801B00360DAC /* FlickrKit.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FlickrKit.pch; path = "FlickrKit OS X/FlickrKit.pch"; sourceTree = SOURCE_ROOT; };
+		5B2B54A71831801B00360DAC /* FlickrKit FrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FlickrKit FrameworkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B2B54B01831801C00360DAC /* FlickrKitTests-Info OS X.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "FlickrKitTests-Info OS X.plist"; path = "../FlickrKitTests/FlickrKitTests-Info OS X.plist"; sourceTree = "<group>"; };
+		5B2B54B21831801C00360DAC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		5B4ED7D418391C8800745B36 /* NSImageJPEGRepresentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSImageJPEGRepresentation.h; sourceTree = "<group>"; };
+		5B4ED7D518391C8800745B36 /* NSImageJPEGRepresentation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSImageJPEGRepresentation.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5B2B548E1831801B00360DAC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2B54CF18318B1700360DAC /* SystemConfiguration.framework in Frameworks */,
+				5B2B54941831801B00360DAC /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B2B54A41831801B00360DAC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2B54AA1831801C00360DAC /* Cocoa.framework in Frameworks */,
+				5B2B54AD1831801C00360DAC /* FlickrKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		552D910D1753951300BE3FEA = {
+			isa = PBXGroup;
+			children = (
+				55B206EA176903DB00A19A12 /* README.md */,
+				55B206EB176903E300A19A12 /* Source Code License.rtf */,
+				552D91E41754AE8900BE3FEA /* Classes */,
+				552D91201753951300BE3FEA /* Supporting Files */,
+				552D913D1753951300BE3FEA /* Tests */,
+				5B2B54AE1831801C00360DAC /* FlickrKit FrameworkTests */,
+				552D91181753951300BE3FEA /* Frameworks */,
+				552D91171753951300BE3FEA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		552D91171753951300BE3FEA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5B2B54921831801B00360DAC /* FlickrKit.framework */,
+				5B2B54A71831801B00360DAC /* FlickrKit FrameworkTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		552D91181753951300BE3FEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				55AEEF59175766EF00B61A3C /* SystemConfiguration.framework */,
+				552D911B1753951300BE3FEA /* Foundation.framework */,
+				552D911D1753951300BE3FEA /* CoreGraphics.framework */,
+				552D91371753951300BE3FEA /* SenTestingKit.framework */,
+				5B2B54931831801B00360DAC /* Cocoa.framework */,
+				5B2B54951831801B00360DAC /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		552D91201753951300BE3FEA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				5B2B549B1831801B00360DAC /* FlickrKit-Info.plist */,
+				5B2B549C1831801B00360DAC /* InfoPlist.strings */,
+				5B2B549F1831801B00360DAC /* FlickrKit.pch */,
+			);
+			name = "Supporting Files";
+			path = "FlickrKit OS X";
+			sourceTree = "<group>";
+		};
+		552D913D1753951300BE3FEA /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				55AEEF4A175661C100B61A3C /* FlickrKitUtilTests.h */,
+				55AEEF4B175661C100B61A3C /* FlickrKitUtilTests.m */,
+				552D921D175504DF00BE3FEA /* FlickrKit_Tests.h */,
+				552D91431753951300BE3FEA /* FlickrKitTests.h */,
+				552D91441753951300BE3FEA /* FlickrKitTests.m */,
+				552D91631753B7EC00BE3FEA /* FlickrKitFailTests.h */,
+				552D91641753B7EC00BE3FEA /* FlickrKitFailTests.m */,
+				552D916A1753C5C900BE3FEA /* FlickrAuthTests.h */,
+				552D916B1753C5C900BE3FEA /* FlickrAuthTests.m */,
+			);
+			name = Tests;
+			path = FlickrKitTests;
+			sourceTree = "<group>";
+		};
+		552D91E41754AE8900BE3FEA /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				5B4ED7D318391C8800745B36 /* FlickrKit OS X */,
+				555AD7DE17662D1300AA91AB /* Model */,
+				55AEEF4D1756644900B61A3C /* Utilities */,
+				552D91E51754AE8A00BE3FEA /* DevedUpKit */,
+				552D91F01754AE8A00BE3FEA /* Network */,
+				55AD4848175CA0E1004AF85C /* FlickrKit */,
+				552D91EC1754AE8A00BE3FEA /* FlickrKit.h */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		552D91E51754AE8A00BE3FEA /* DevedUpKit */ = {
+			isa = PBXGroup;
+			children = (
+				552D921A1754DC6500BE3FEA /* FKDUDiskCache.h */,
+				552D92161754DBAC00BE3FEA /* FKDUDefaultDiskCache.h */,
+				552D92171754DBAC00BE3FEA /* FKDUDefaultDiskCache.m */,
+				552D91E61754AE8A00BE3FEA /* FKDUBlocks.h */,
+				552D91E71754AE8A00BE3FEA /* FKDUBlocks.m */,
+				552D91E81754AE8A00BE3FEA /* FKDUConcurrentOperation.h */,
+				552D91E91754AE8A00BE3FEA /* FKDUConcurrentOperation.m */,
+				55AD48E7175F3217004AF85C /* FKDUNetworkOperation.h */,
+				55AD48E8175F3217004AF85C /* FKDUNetworkOperation.m */,
+				552D91EA1754AE8A00BE3FEA /* FKDUNetworkController.h */,
+				552D91EB1754AE8A00BE3FEA /* FKDUNetworkController.m */,
+				55A5B666176613F900745C71 /* FKDUStreamUtil.h */,
+				55A5B667176613F900745C71 /* FKDUStreamUtil.m */,
+			);
+			path = DevedUpKit;
+			sourceTree = "<group>";
+		};
+		552D91F01754AE8A00BE3FEA /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				552D91F11754AE8A00BE3FEA /* FKFlickrNetworkOperation.h */,
+				552D91F21754AE8A00BE3FEA /* FKFlickrNetworkOperation.m */,
+				55AD49041760DBE4004AF85C /* FKImageUploadNetworkOperation.h */,
+				55AD49051760DBE5004AF85C /* FKImageUploadNetworkOperation.m */,
+				55AD49081760E545004AF85C /* FKUploadRespone.h */,
+				55AD49091760E546004AF85C /* FKUploadRespone.m */,
+				552D91F31754AE8A00BE3FEA /* FKURLBuilder.h */,
+				552D91F41754AE8A00BE3FEA /* FKURLBuilder.m */,
+				55AEEF55175766D500B61A3C /* FKDUReachability.h */,
+				55AEEF56175766D500B61A3C /* FKDUReachability.m */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		555AD7DE17662D1300AA91AB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D2617678A9700E84674 /* Generated */,
+				555ADB1C1766640100AA91AB /* FKFlickrAPIMethod.h */,
+				55958DEF1767BD7B0078905C /* FKAPIMethods.h */,
+			);
+			name = Model;
+			sourceTree = "<group>";
+		};
+		555F2D2617678A9700E84674 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D2717678A9700E84674 /* Activity */,
+				555F2D2C17678A9700E84674 /* Auth */,
+				555F2D3A17678A9700E84674 /* Blogs */,
+				555F2D4117678A9700E84674 /* Cameras */,
+				555F2D4617678A9700E84674 /* Collections */,
+				555F2D4B17678A9700E84674 /* Commons */,
+				555F2D4E17678A9700E84674 /* Contacts */,
+				555F2D5717678A9700E84674 /* Favorites */,
+				555F2D6217678A9700E84674 /* Galleries */,
+				555F2D7517678A9700E84674 /* Groups */,
+				555F2DA317678A9700E84674 /* Interestingness */,
+				555F2DA617678A9700E84674 /* Machinetags */,
+				555F2DB117678A9700E84674 /* Panda */,
+				555F2DB617678A9700E84674 /* People */,
+				555F2DCB17678A9700E84674 /* Photos */,
+				555F2E4717678A9700E84674 /* Photosets */,
+				555F2E6D17678A9700E84674 /* Places */,
+				555F2E8C17678A9800E84674 /* Prefs */,
+				555F2E9717678A9800E84674 /* Push */,
+				555F2EA017678A9800E84674 /* Reflection */,
+				555F2EA517678A9800E84674 /* Stats */,
+				555F2EC417678A9800E84674 /* Tags */,
+				555F2ED717678A9800E84674 /* Test */,
+				555F2EDE17678A9800E84674 /* Urls */,
+			);
+			name = Generated;
+			path = Model/Generated;
+			sourceTree = "<group>";
+		};
+		555F2D2717678A9700E84674 /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D2817678A9700E84674 /* FKFlickrActivityUserComments.h */,
+				555F2D2917678A9700E84674 /* FKFlickrActivityUserComments.m */,
+				555F2D2A17678A9700E84674 /* FKFlickrActivityUserPhotos.h */,
+				555F2D2B17678A9700E84674 /* FKFlickrActivityUserPhotos.m */,
+			);
+			path = Activity;
+			sourceTree = "<group>";
+		};
+		555F2D2C17678A9700E84674 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D2D17678A9700E84674 /* FKFlickrAuthCheckToken.h */,
+				555F2D2E17678A9700E84674 /* FKFlickrAuthCheckToken.m */,
+				555F2D2F17678A9700E84674 /* FKFlickrAuthGetFrob.h */,
+				555F2D3017678A9700E84674 /* FKFlickrAuthGetFrob.m */,
+				555F2D3117678A9700E84674 /* FKFlickrAuthGetFullToken.h */,
+				555F2D3217678A9700E84674 /* FKFlickrAuthGetFullToken.m */,
+				555F2D3317678A9700E84674 /* FKFlickrAuthGetToken.h */,
+				555F2D3417678A9700E84674 /* FKFlickrAuthGetToken.m */,
+				555F2D3517678A9700E84674 /* Oauth */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		555F2D3517678A9700E84674 /* Oauth */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D3617678A9700E84674 /* FKFlickrAuthOauthCheckToken.h */,
+				555F2D3717678A9700E84674 /* FKFlickrAuthOauthCheckToken.m */,
+				555F2D3817678A9700E84674 /* FKFlickrAuthOauthGetAccessToken.h */,
+				555F2D3917678A9700E84674 /* FKFlickrAuthOauthGetAccessToken.m */,
+			);
+			path = Oauth;
+			sourceTree = "<group>";
+		};
+		555F2D3A17678A9700E84674 /* Blogs */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D3B17678A9700E84674 /* FKFlickrBlogsGetList.h */,
+				555F2D3C17678A9700E84674 /* FKFlickrBlogsGetList.m */,
+				555F2D3D17678A9700E84674 /* FKFlickrBlogsGetServices.h */,
+				555F2D3E17678A9700E84674 /* FKFlickrBlogsGetServices.m */,
+				555F2D3F17678A9700E84674 /* FKFlickrBlogsPostPhoto.h */,
+				555F2D4017678A9700E84674 /* FKFlickrBlogsPostPhoto.m */,
+			);
+			path = Blogs;
+			sourceTree = "<group>";
+		};
+		555F2D4117678A9700E84674 /* Cameras */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D4217678A9700E84674 /* FKFlickrCamerasGetBrandModels.h */,
+				555F2D4317678A9700E84674 /* FKFlickrCamerasGetBrandModels.m */,
+				555F2D4417678A9700E84674 /* FKFlickrCamerasGetBrands.h */,
+				555F2D4517678A9700E84674 /* FKFlickrCamerasGetBrands.m */,
+			);
+			path = Cameras;
+			sourceTree = "<group>";
+		};
+		555F2D4617678A9700E84674 /* Collections */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D4717678A9700E84674 /* FKFlickrCollectionsGetInfo.h */,
+				555F2D4817678A9700E84674 /* FKFlickrCollectionsGetInfo.m */,
+				555F2D4917678A9700E84674 /* FKFlickrCollectionsGetTree.h */,
+				555F2D4A17678A9700E84674 /* FKFlickrCollectionsGetTree.m */,
+			);
+			path = Collections;
+			sourceTree = "<group>";
+		};
+		555F2D4B17678A9700E84674 /* Commons */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D4C17678A9700E84674 /* FKFlickrCommonsGetInstitutions.h */,
+				555F2D4D17678A9700E84674 /* FKFlickrCommonsGetInstitutions.m */,
+			);
+			path = Commons;
+			sourceTree = "<group>";
+		};
+		555F2D4E17678A9700E84674 /* Contacts */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D4F17678A9700E84674 /* FKFlickrContactsGetList.h */,
+				555F2D5017678A9700E84674 /* FKFlickrContactsGetList.m */,
+				555F2D5117678A9700E84674 /* FKFlickrContactsGetListRecentlyUploaded.h */,
+				555F2D5217678A9700E84674 /* FKFlickrContactsGetListRecentlyUploaded.m */,
+				555F2D5317678A9700E84674 /* FKFlickrContactsGetPublicList.h */,
+				555F2D5417678A9700E84674 /* FKFlickrContactsGetPublicList.m */,
+				555F2D5517678A9700E84674 /* FKFlickrContactsGetTaggingSuggestions.h */,
+				555F2D5617678A9700E84674 /* FKFlickrContactsGetTaggingSuggestions.m */,
+			);
+			path = Contacts;
+			sourceTree = "<group>";
+		};
+		555F2D5717678A9700E84674 /* Favorites */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D5817678A9700E84674 /* FKFlickrFavoritesAdd.h */,
+				555F2D5917678A9700E84674 /* FKFlickrFavoritesAdd.m */,
+				555F2D5A17678A9700E84674 /* FKFlickrFavoritesGetContext.h */,
+				555F2D5B17678A9700E84674 /* FKFlickrFavoritesGetContext.m */,
+				555F2D5C17678A9700E84674 /* FKFlickrFavoritesGetList.h */,
+				555F2D5D17678A9700E84674 /* FKFlickrFavoritesGetList.m */,
+				555F2D5E17678A9700E84674 /* FKFlickrFavoritesGetPublicList.h */,
+				555F2D5F17678A9700E84674 /* FKFlickrFavoritesGetPublicList.m */,
+				555F2D6017678A9700E84674 /* FKFlickrFavoritesRemove.h */,
+				555F2D6117678A9700E84674 /* FKFlickrFavoritesRemove.m */,
+			);
+			path = Favorites;
+			sourceTree = "<group>";
+		};
+		555F2D6217678A9700E84674 /* Galleries */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D6317678A9700E84674 /* FKFlickrGalleriesAddPhoto.h */,
+				555F2D6417678A9700E84674 /* FKFlickrGalleriesAddPhoto.m */,
+				555F2D6517678A9700E84674 /* FKFlickrGalleriesCreate.h */,
+				555F2D6617678A9700E84674 /* FKFlickrGalleriesCreate.m */,
+				555F2D6717678A9700E84674 /* FKFlickrGalleriesEditMeta.h */,
+				555F2D6817678A9700E84674 /* FKFlickrGalleriesEditMeta.m */,
+				555F2D6917678A9700E84674 /* FKFlickrGalleriesEditPhoto.h */,
+				555F2D6A17678A9700E84674 /* FKFlickrGalleriesEditPhoto.m */,
+				555F2D6B17678A9700E84674 /* FKFlickrGalleriesEditPhotos.h */,
+				555F2D6C17678A9700E84674 /* FKFlickrGalleriesEditPhotos.m */,
+				555F2D6D17678A9700E84674 /* FKFlickrGalleriesGetInfo.h */,
+				555F2D6E17678A9700E84674 /* FKFlickrGalleriesGetInfo.m */,
+				555F2D6F17678A9700E84674 /* FKFlickrGalleriesGetList.h */,
+				555F2D7017678A9700E84674 /* FKFlickrGalleriesGetList.m */,
+				555F2D7117678A9700E84674 /* FKFlickrGalleriesGetListForPhoto.h */,
+				555F2D7217678A9700E84674 /* FKFlickrGalleriesGetListForPhoto.m */,
+				555F2D7317678A9700E84674 /* FKFlickrGalleriesGetPhotos.h */,
+				555F2D7417678A9700E84674 /* FKFlickrGalleriesGetPhotos.m */,
+			);
+			path = Galleries;
+			sourceTree = "<group>";
+		};
+		555F2D7517678A9700E84674 /* Groups */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D7617678A9700E84674 /* Discuss */,
+				555F2D8917678A9700E84674 /* FKFlickrGroupsBrowse.h */,
+				555F2D8A17678A9700E84674 /* FKFlickrGroupsBrowse.m */,
+				555F2D8B17678A9700E84674 /* FKFlickrGroupsGetInfo.h */,
+				555F2D8C17678A9700E84674 /* FKFlickrGroupsGetInfo.m */,
+				555F2D8D17678A9700E84674 /* FKFlickrGroupsJoin.h */,
+				555F2D8E17678A9700E84674 /* FKFlickrGroupsJoin.m */,
+				555F2D8F17678A9700E84674 /* FKFlickrGroupsJoinRequest.h */,
+				555F2D9017678A9700E84674 /* FKFlickrGroupsJoinRequest.m */,
+				555F2D9117678A9700E84674 /* FKFlickrGroupsLeave.h */,
+				555F2D9217678A9700E84674 /* FKFlickrGroupsLeave.m */,
+				555F2D9317678A9700E84674 /* FKFlickrGroupsSearch.h */,
+				555F2D9417678A9700E84674 /* FKFlickrGroupsSearch.m */,
+				555F2D9517678A9700E84674 /* Members */,
+				555F2D9817678A9700E84674 /* Pools */,
+			);
+			path = Groups;
+			sourceTree = "<group>";
+		};
+		555F2D7617678A9700E84674 /* Discuss */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D7717678A9700E84674 /* Replies */,
+				555F2D8217678A9700E84674 /* Topics */,
+			);
+			path = Discuss;
+			sourceTree = "<group>";
+		};
+		555F2D7717678A9700E84674 /* Replies */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D7817678A9700E84674 /* FKFlickrGroupsDiscussRepliesAdd.h */,
+				555F2D7917678A9700E84674 /* FKFlickrGroupsDiscussRepliesAdd.m */,
+				555F2D7A17678A9700E84674 /* FKFlickrGroupsDiscussRepliesDelete.h */,
+				555F2D7B17678A9700E84674 /* FKFlickrGroupsDiscussRepliesDelete.m */,
+				555F2D7C17678A9700E84674 /* FKFlickrGroupsDiscussRepliesEdit.h */,
+				555F2D7D17678A9700E84674 /* FKFlickrGroupsDiscussRepliesEdit.m */,
+				555F2D7E17678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetInfo.h */,
+				555F2D7F17678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetInfo.m */,
+				555F2D8017678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetList.h */,
+				555F2D8117678A9700E84674 /* FKFlickrGroupsDiscussRepliesGetList.m */,
+			);
+			path = Replies;
+			sourceTree = "<group>";
+		};
+		555F2D8217678A9700E84674 /* Topics */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D8317678A9700E84674 /* FKFlickrGroupsDiscussTopicsAdd.h */,
+				555F2D8417678A9700E84674 /* FKFlickrGroupsDiscussTopicsAdd.m */,
+				555F2D8517678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetInfo.h */,
+				555F2D8617678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetInfo.m */,
+				555F2D8717678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetList.h */,
+				555F2D8817678A9700E84674 /* FKFlickrGroupsDiscussTopicsGetList.m */,
+			);
+			path = Topics;
+			sourceTree = "<group>";
+		};
+		555F2D9517678A9700E84674 /* Members */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D9617678A9700E84674 /* FKFlickrGroupsMembersGetList.h */,
+				555F2D9717678A9700E84674 /* FKFlickrGroupsMembersGetList.m */,
+			);
+			path = Members;
+			sourceTree = "<group>";
+		};
+		555F2D9817678A9700E84674 /* Pools */ = {
+			isa = PBXGroup;
+			children = (
+				555F2D9917678A9700E84674 /* FKFlickrGroupsPoolsAdd.h */,
+				555F2D9A17678A9700E84674 /* FKFlickrGroupsPoolsAdd.m */,
+				555F2D9B17678A9700E84674 /* FKFlickrGroupsPoolsGetContext.h */,
+				555F2D9C17678A9700E84674 /* FKFlickrGroupsPoolsGetContext.m */,
+				555F2D9D17678A9700E84674 /* FKFlickrGroupsPoolsGetGroups.h */,
+				555F2D9E17678A9700E84674 /* FKFlickrGroupsPoolsGetGroups.m */,
+				555F2D9F17678A9700E84674 /* FKFlickrGroupsPoolsGetPhotos.h */,
+				555F2DA017678A9700E84674 /* FKFlickrGroupsPoolsGetPhotos.m */,
+				555F2DA117678A9700E84674 /* FKFlickrGroupsPoolsRemove.h */,
+				555F2DA217678A9700E84674 /* FKFlickrGroupsPoolsRemove.m */,
+			);
+			path = Pools;
+			sourceTree = "<group>";
+		};
+		555F2DA317678A9700E84674 /* Interestingness */ = {
+			isa = PBXGroup;
+			children = (
+				555F2DA417678A9700E84674 /* FKFlickrInterestingnessGetList.h */,
+				555F2DA517678A9700E84674 /* FKFlickrInterestingnessGetList.m */,
+			);
+			path = Interestingness;
+			sourceTree = "<group>";
+		};
+		555F2DA617678A9700E84674 /* Machinetags */ = {
+			isa = PBXGroup;
+			children = (
+				555F2DA717678A9700E84674 /* FKFlickrMachinetagsGetNamespaces.h */,
+				555F2DA817678A9700E84674 /* FKFlickrMachinetagsGetNamespaces.m */,
+				555F2DA917678A9700E84674 /* FKFlickrMachinetagsGetPairs.h */,
+				555F2DAA17678A9700E84674 /* FKFlickrMachinetagsGetPairs.m */,
+				555F2DAB17678A9700E84674 /* FKFlickrMachinetagsGetPredicates.h */,
+				555F2DAC17678A9700E84674 /* FKFlickrMachinetagsGetPredicates.m */,
+				555F2DAD17678A9700E84674 /* FKFlickrMachinetagsGetRecentValues.h */,
+				555F2DAE17678A9700E84674 /* FKFlickrMachinetagsGetRecentValues.m */,
+				555F2DAF17678A9700E84674 /* FKFlickrMachinetagsGetValues.h */,
+				555F2DB017678A9700E84674 /* FKFlickrMachinetagsGetValues.m */,
+			);
+			path = Machinetags;
+			sourceTree = "<group>";
+		};
+		555F2DB117678A9700E84674 /* Panda */ = {
+			isa = PBXGroup;
+			children = (
+				555F2DB217678A9700E84674 /* FKFlickrPandaGetList.h */,
+				555F2DB317678A9700E84674 /* FKFlickrPandaGetList.m */,
+				555F2DB417678A9700E84674 /* FKFlickrPandaGetPhotos.h */,
+				555F2DB517678A9700E84674 /* FKFlickrPandaGetPhotos.m */,
+			);
+			path = Panda;
+			sourceTree = "<group>";
+		};
+		555F2DB617678A9700E84674 /* People */ = {
+			isa = PBXGroup;
+			children = (
+				555F2DB717678A9700E84674 /* FKFlickrPeopleFindByEmail.h */,
+				555F2DB817678A9700E84674 /* FKFlickrPeopleFindByEmail.m */,
+				555F2DB917678A9700E84674 /* FKFlickrPeopleFindByUsername.h */,
+				555F2DBA17678A9700E84674 /* FKFlickrPeopleFindByUsername.m */,
+				555F2DBB17678A9700E84674 /* FKFlickrPeopleGetGroups.h */,
+				555F2DBC17678A9700E84674 /* FKFlickrPeopleGetGroups.m */,
+				555F2DBD17678A9700E84674 /* FKFlickrPeopleGetInfo.h */,
+				555F2DBE17678A9700E84674 /* FKFlickrPeopleGetInfo.m */,
+				555F2DBF17678A9700E84674 /* FKFlickrPeopleGetLimits.h */,
+				555F2DC017678A9700E84674 /* FKFlickrPeopleGetLimits.m */,
+				555F2DC117678A9700E84674 /* FKFlickrPeopleGetPhotos.h */,
+				555F2DC217678A9700E84674 /* FKFlickrPeopleGetPhotos.m */,
+				555F2DC317678A9700E84674 /* FKFlickrPeopleGetPhotosOf.h */,
+				555F2DC417678A9700E84674 /* FKFlickrPeopleGetPhotosOf.m */,
+				555F2DC517678A9700E84674 /* FKFlickrPeopleGetPublicGroups.h */,
+				555F2DC617678A9700E84674 /* FKFlickrPeopleGetPublicGroups.m */,
+				555F2DC717678A9700E84674 /* FKFlickrPeopleGetPublicPhotos.h */,
+				555F2DC817678A9700E84674 /* FKFlickrPeopleGetPublicPhotos.m */,
+				555F2DC917678A9700E84674 /* FKFlickrPeopleGetUploadStatus.h */,
+				555F2DCA17678A9700E84674 /* FKFlickrPeopleGetUploadStatus.m */,
+			);
+			path = People;
+			sourceTree = "<group>";
+		};
+		555F2DCB17678A9700E84674 /* Photos */ = {
+			isa = PBXGroup;
+			children = (
+				555F2DCC17678A9700E84674 /* Comments */,
+				555F2DD717678A9700E84674 /* FKFlickrPhotosAddTags.h */,
+				555F2DD817678A9700E84674 /* FKFlickrPhotosAddTags.m */,
+				555F2DD917678A9700E84674 /* FKFlickrPhotosDelete.h */,
+				555F2DDA17678A9700E84674 /* FKFlickrPhotosDelete.m */,
+				555F2DDB17678A9700E84674 /* FKFlickrPhotosGetAllContexts.h */,
+				555F2DDC17678A9700E84674 /* FKFlickrPhotosGetAllContexts.m */,
+				555F2DDD17678A9700E84674 /* FKFlickrPhotosGetContactsPhotos.h */,
+				555F2DDE17678A9700E84674 /* FKFlickrPhotosGetContactsPhotos.m */,
+				555F2DDF17678A9700E84674 /* FKFlickrPhotosGetContactsPublicPhotos.h */,
+				555F2DE017678A9700E84674 /* FKFlickrPhotosGetContactsPublicPhotos.m */,
+				555F2DE117678A9700E84674 /* FKFlickrPhotosGetContext.h */,
+				555F2DE217678A9700E84674 /* FKFlickrPhotosGetContext.m */,
+				555F2DE317678A9700E84674 /* FKFlickrPhotosGetCounts.h */,
+				555F2DE417678A9700E84674 /* FKFlickrPhotosGetCounts.m */,
+				555F2DE517678A9700E84674 /* FKFlickrPhotosGetExif.h */,
+				555F2DE617678A9700E84674 /* FKFlickrPhotosGetExif.m */,
+				555F2DE717678A9700E84674 /* FKFlickrPhotosGetFavorites.h */,
+				555F2DE817678A9700E84674 /* FKFlickrPhotosGetFavorites.m */,
+				555F2DE917678A9700E84674 /* FKFlickrPhotosGetInfo.h */,
+				555F2DEA17678A9700E84674 /* FKFlickrPhotosGetInfo.m */,
+				555F2DEB17678A9700E84674 /* FKFlickrPhotosGetNotInSet.h */,
+				555F2DEC17678A9700E84674 /* FKFlickrPhotosGetNotInSet.m */,
+				555F2DED17678A9700E84674 /* FKFlickrPhotosGetPerms.h */,
+				555F2DEE17678A9700E84674 /* FKFlickrPhotosGetPerms.m */,
+				555F2DEF17678A9700E84674 /* FKFlickrPhotosGetRecent.h */,
+				555F2DF017678A9700E84674 /* FKFlickrPhotosGetRecent.m */,
+				555F2DF117678A9700E84674 /* FKFlickrPhotosGetSizes.h */,
+				555F2DF217678A9700E84674 /* FKFlickrPhotosGetSizes.m */,
+				555F2DF317678A9700E84674 /* FKFlickrPhotosGetUntagged.h */,
+				555F2DF417678A9700E84674 /* FKFlickrPhotosGetUntagged.m */,
+				555F2DF517678A9700E84674 /* FKFlickrPhotosGetWithGeoData.h */,
+				555F2DF617678A9700E84674 /* FKFlickrPhotosGetWithGeoData.m */,
+				555F2DF717678A9700E84674 /* FKFlickrPhotosGetWithoutGeoData.h */,
+				555F2DF817678A9700E84674 /* FKFlickrPhotosGetWithoutGeoData.m */,
+				555F2DF917678A9700E84674 /* FKFlickrPhotosRecentlyUpdated.h */,
+				555F2DFA17678A9700E84674 /* FKFlickrPhotosRecentlyUpdated.m */,
+				555F2DFB17678A9700E84674 /* FKFlickrPhotosRemoveTag.h */,
+				555F2DFC17678A9700E84674 /* FKFlickrPhotosRemoveTag.m */,
+				555F2DFD17678A9700E84674 /* FKFlickrPhotosSearch.h */,
+				555F2DFE17678A9700E84674 /* FKFlickrPhotosSearch.m */,
+				555F2DFF17678A9700E84674 /* FKFlickrPhotosSetContentType.h */,
+				555F2E0017678A9700E84674 /* FKFlickrPhotosSetContentType.m */,
+				555F2E0117678A9700E84674 /* FKFlickrPhotosSetDates.h */,
+				555F2E0217678A9700E84674 /* FKFlickrPhotosSetDates.m */,
+				555F2E0317678A9700E84674 /* FKFlickrPhotosSetMeta.h */,
+				555F2E0417678A9700E84674 /* FKFlickrPhotosSetMeta.m */,
+				555F2E0517678A9700E84674 /* FKFlickrPhotosSetPerms.h */,
+				555F2E0617678A9700E84674 /* FKFlickrPhotosSetPerms.m */,
+				555F2E0717678A9700E84674 /* FKFlickrPhotosSetSafetyLevel.h */,
+				555F2E0817678A9700E84674 /* FKFlickrPhotosSetSafetyLevel.m */,
+				555F2E0917678A9700E84674 /* FKFlickrPhotosSetTags.h */,
+				555F2E0A17678A9700E84674 /* FKFlickrPhotosSetTags.m */,
+				555F2E0B17678A9700E84674 /* Geo */,
+				555F2E1F17678A9700E84674 /* Licenses */,
+				555F2E2417678A9700E84674 /* Notes */,
+				555F2E2B17678A9700E84674 /* People */,
+				555F2E3617678A9700E84674 /* Suggestions */,
+				555F2E4117678A9700E84674 /* Transform */,
+				555F2E4417678A9700E84674 /* Upload */,
+			);
+			path = Photos;
+			sourceTree = "<group>";
+		};
+		555F2DCC17678A9700E84674 /* Comments */ = {
+			isa = PBXGroup;
+			children = (
+				555F2DCD17678A9700E84674 /* FKFlickrPhotosCommentsAddComment.h */,
+				555F2DCE17678A9700E84674 /* FKFlickrPhotosCommentsAddComment.m */,
+				555F2DCF17678A9700E84674 /* FKFlickrPhotosCommentsDeleteComment.h */,
+				555F2DD017678A9700E84674 /* FKFlickrPhotosCommentsDeleteComment.m */,
+				555F2DD117678A9700E84674 /* FKFlickrPhotosCommentsEditComment.h */,
+				555F2DD217678A9700E84674 /* FKFlickrPhotosCommentsEditComment.m */,
+				555F2DD317678A9700E84674 /* FKFlickrPhotosCommentsGetList.h */,
+				555F2DD417678A9700E84674 /* FKFlickrPhotosCommentsGetList.m */,
+				555F2DD517678A9700E84674 /* FKFlickrPhotosCommentsGetRecentForContacts.h */,
+				555F2DD617678A9700E84674 /* FKFlickrPhotosCommentsGetRecentForContacts.m */,
+			);
+			path = Comments;
+			sourceTree = "<group>";
+		};
+		555F2E0B17678A9700E84674 /* Geo */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E0D17678A9700E84674 /* FKFlickrPhotosGeoBatchCorrectLocation.h */,
+				555F2E0E17678A9700E84674 /* FKFlickrPhotosGeoBatchCorrectLocation.m */,
+				555F2E0F17678A9700E84674 /* FKFlickrPhotosGeoCorrectLocation.h */,
+				555F2E1017678A9700E84674 /* FKFlickrPhotosGeoCorrectLocation.m */,
+				555F2E1117678A9700E84674 /* FKFlickrPhotosGeoGetLocation.h */,
+				555F2E1217678A9700E84674 /* FKFlickrPhotosGeoGetLocation.m */,
+				555F2E1317678A9700E84674 /* FKFlickrPhotosGeoGetPerms.h */,
+				555F2E1417678A9700E84674 /* FKFlickrPhotosGeoGetPerms.m */,
+				555F2E1517678A9700E84674 /* FKFlickrPhotosGeoPhotosForLocation.h */,
+				555F2E1617678A9700E84674 /* FKFlickrPhotosGeoPhotosForLocation.m */,
+				555F2E1717678A9700E84674 /* FKFlickrPhotosGeoRemoveLocation.h */,
+				555F2E1817678A9700E84674 /* FKFlickrPhotosGeoRemoveLocation.m */,
+				555F2E1917678A9700E84674 /* FKFlickrPhotosGeoSetContext.h */,
+				555F2E1A17678A9700E84674 /* FKFlickrPhotosGeoSetContext.m */,
+				555F2E1B17678A9700E84674 /* FKFlickrPhotosGeoSetLocation.h */,
+				555F2E1C17678A9700E84674 /* FKFlickrPhotosGeoSetLocation.m */,
+				555F2E1D17678A9700E84674 /* FKFlickrPhotosGeoSetPerms.h */,
+				555F2E1E17678A9700E84674 /* FKFlickrPhotosGeoSetPerms.m */,
+			);
+			path = Geo;
+			sourceTree = "<group>";
+		};
+		555F2E1F17678A9700E84674 /* Licenses */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E2017678A9700E84674 /* FKFlickrPhotosLicensesGetInfo.h */,
+				555F2E2117678A9700E84674 /* FKFlickrPhotosLicensesGetInfo.m */,
+				555F2E2217678A9700E84674 /* FKFlickrPhotosLicensesSetLicense.h */,
+				555F2E2317678A9700E84674 /* FKFlickrPhotosLicensesSetLicense.m */,
+			);
+			path = Licenses;
+			sourceTree = "<group>";
+		};
+		555F2E2417678A9700E84674 /* Notes */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E2517678A9700E84674 /* FKFlickrPhotosNotesAdd.h */,
+				555F2E2617678A9700E84674 /* FKFlickrPhotosNotesAdd.m */,
+				555F2E2717678A9700E84674 /* FKFlickrPhotosNotesDelete.h */,
+				555F2E2817678A9700E84674 /* FKFlickrPhotosNotesDelete.m */,
+				555F2E2917678A9700E84674 /* FKFlickrPhotosNotesEdit.h */,
+				555F2E2A17678A9700E84674 /* FKFlickrPhotosNotesEdit.m */,
+			);
+			path = Notes;
+			sourceTree = "<group>";
+		};
+		555F2E2B17678A9700E84674 /* People */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E2C17678A9700E84674 /* FKFlickrPhotosPeopleAdd.h */,
+				555F2E2D17678A9700E84674 /* FKFlickrPhotosPeopleAdd.m */,
+				555F2E2E17678A9700E84674 /* FKFlickrPhotosPeopleDelete.h */,
+				555F2E2F17678A9700E84674 /* FKFlickrPhotosPeopleDelete.m */,
+				555F2E3017678A9700E84674 /* FKFlickrPhotosPeopleDeleteCoords.h */,
+				555F2E3117678A9700E84674 /* FKFlickrPhotosPeopleDeleteCoords.m */,
+				555F2E3217678A9700E84674 /* FKFlickrPhotosPeopleEditCoords.h */,
+				555F2E3317678A9700E84674 /* FKFlickrPhotosPeopleEditCoords.m */,
+				555F2E3417678A9700E84674 /* FKFlickrPhotosPeopleGetList.h */,
+				555F2E3517678A9700E84674 /* FKFlickrPhotosPeopleGetList.m */,
+			);
+			path = People;
+			sourceTree = "<group>";
+		};
+		555F2E3617678A9700E84674 /* Suggestions */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E3717678A9700E84674 /* FKFlickrPhotosSuggestionsApproveSuggestion.h */,
+				555F2E3817678A9700E84674 /* FKFlickrPhotosSuggestionsApproveSuggestion.m */,
+				555F2E3917678A9700E84674 /* FKFlickrPhotosSuggestionsGetList.h */,
+				555F2E3A17678A9700E84674 /* FKFlickrPhotosSuggestionsGetList.m */,
+				555F2E3B17678A9700E84674 /* FKFlickrPhotosSuggestionsRejectSuggestion.h */,
+				555F2E3C17678A9700E84674 /* FKFlickrPhotosSuggestionsRejectSuggestion.m */,
+				555F2E3D17678A9700E84674 /* FKFlickrPhotosSuggestionsRemoveSuggestion.h */,
+				555F2E3E17678A9700E84674 /* FKFlickrPhotosSuggestionsRemoveSuggestion.m */,
+				555F2E3F17678A9700E84674 /* FKFlickrPhotosSuggestionsSuggestLocation.h */,
+				555F2E4017678A9700E84674 /* FKFlickrPhotosSuggestionsSuggestLocation.m */,
+			);
+			path = Suggestions;
+			sourceTree = "<group>";
+		};
+		555F2E4117678A9700E84674 /* Transform */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E4217678A9700E84674 /* FKFlickrPhotosTransformRotate.h */,
+				555F2E4317678A9700E84674 /* FKFlickrPhotosTransformRotate.m */,
+			);
+			path = Transform;
+			sourceTree = "<group>";
+		};
+		555F2E4417678A9700E84674 /* Upload */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E4517678A9700E84674 /* FKFlickrPhotosUploadCheckTickets.h */,
+				555F2E4617678A9700E84674 /* FKFlickrPhotosUploadCheckTickets.m */,
+			);
+			path = Upload;
+			sourceTree = "<group>";
+		};
+		555F2E4717678A9700E84674 /* Photosets */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E4817678A9700E84674 /* Comments */,
+				555F2E5117678A9700E84674 /* FKFlickrPhotosetsAddPhoto.h */,
+				555F2E5217678A9700E84674 /* FKFlickrPhotosetsAddPhoto.m */,
+				555F2E5317678A9700E84674 /* FKFlickrPhotosetsCreate.h */,
+				555F2E5417678A9700E84674 /* FKFlickrPhotosetsCreate.m */,
+				555F2E5517678A9700E84674 /* FKFlickrPhotosetsDelete.h */,
+				555F2E5617678A9700E84674 /* FKFlickrPhotosetsDelete.m */,
+				555F2E5717678A9700E84674 /* FKFlickrPhotosetsEditMeta.h */,
+				555F2E5817678A9700E84674 /* FKFlickrPhotosetsEditMeta.m */,
+				555F2E5917678A9700E84674 /* FKFlickrPhotosetsEditPhotos.h */,
+				555F2E5A17678A9700E84674 /* FKFlickrPhotosetsEditPhotos.m */,
+				555F2E5B17678A9700E84674 /* FKFlickrPhotosetsGetContext.h */,
+				555F2E5C17678A9700E84674 /* FKFlickrPhotosetsGetContext.m */,
+				555F2E5D17678A9700E84674 /* FKFlickrPhotosetsGetInfo.h */,
+				555F2E5E17678A9700E84674 /* FKFlickrPhotosetsGetInfo.m */,
+				555F2E5F17678A9700E84674 /* FKFlickrPhotosetsGetList.h */,
+				555F2E6017678A9700E84674 /* FKFlickrPhotosetsGetList.m */,
+				555F2E6117678A9700E84674 /* FKFlickrPhotosetsGetPhotos.h */,
+				555F2E6217678A9700E84674 /* FKFlickrPhotosetsGetPhotos.m */,
+				555F2E6317678A9700E84674 /* FKFlickrPhotosetsOrderSets.h */,
+				555F2E6417678A9700E84674 /* FKFlickrPhotosetsOrderSets.m */,
+				555F2E6517678A9700E84674 /* FKFlickrPhotosetsRemovePhoto.h */,
+				555F2E6617678A9700E84674 /* FKFlickrPhotosetsRemovePhoto.m */,
+				555F2E6717678A9700E84674 /* FKFlickrPhotosetsRemovePhotos.h */,
+				555F2E6817678A9700E84674 /* FKFlickrPhotosetsRemovePhotos.m */,
+				555F2E6917678A9700E84674 /* FKFlickrPhotosetsReorderPhotos.h */,
+				555F2E6A17678A9700E84674 /* FKFlickrPhotosetsReorderPhotos.m */,
+				555F2E6B17678A9700E84674 /* FKFlickrPhotosetsSetPrimaryPhoto.h */,
+				555F2E6C17678A9700E84674 /* FKFlickrPhotosetsSetPrimaryPhoto.m */,
+			);
+			path = Photosets;
+			sourceTree = "<group>";
+		};
+		555F2E4817678A9700E84674 /* Comments */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E4917678A9700E84674 /* FKFlickrPhotosetsCommentsAddComment.h */,
+				555F2E4A17678A9700E84674 /* FKFlickrPhotosetsCommentsAddComment.m */,
+				555F2E4B17678A9700E84674 /* FKFlickrPhotosetsCommentsDeleteComment.h */,
+				555F2E4C17678A9700E84674 /* FKFlickrPhotosetsCommentsDeleteComment.m */,
+				555F2E4D17678A9700E84674 /* FKFlickrPhotosetsCommentsEditComment.h */,
+				555F2E4E17678A9700E84674 /* FKFlickrPhotosetsCommentsEditComment.m */,
+				555F2E4F17678A9700E84674 /* FKFlickrPhotosetsCommentsGetList.h */,
+				555F2E5017678A9700E84674 /* FKFlickrPhotosetsCommentsGetList.m */,
+			);
+			path = Comments;
+			sourceTree = "<group>";
+		};
+		555F2E6D17678A9700E84674 /* Places */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E6E17678A9700E84674 /* FKFlickrPlacesFind.h */,
+				555F2E6F17678A9700E84674 /* FKFlickrPlacesFind.m */,
+				555F2E7017678A9700E84674 /* FKFlickrPlacesFindByLatLon.h */,
+				555F2E7117678A9700E84674 /* FKFlickrPlacesFindByLatLon.m */,
+				555F2E7217678A9700E84674 /* FKFlickrPlacesGetChildrenWithPhotosPublic.h */,
+				555F2E7317678A9700E84674 /* FKFlickrPlacesGetChildrenWithPhotosPublic.m */,
+				555F2E7417678A9700E84674 /* FKFlickrPlacesGetInfo.h */,
+				555F2E7517678A9700E84674 /* FKFlickrPlacesGetInfo.m */,
+				555F2E7617678A9700E84674 /* FKFlickrPlacesGetInfoByUrl.h */,
+				555F2E7717678A9700E84674 /* FKFlickrPlacesGetInfoByUrl.m */,
+				555F2E7817678A9700E84674 /* FKFlickrPlacesGetPlaceTypes.h */,
+				555F2E7917678A9700E84674 /* FKFlickrPlacesGetPlaceTypes.m */,
+				555F2E7A17678A9700E84674 /* FKFlickrPlacesGetShapeHistory.h */,
+				555F2E7B17678A9700E84674 /* FKFlickrPlacesGetShapeHistory.m */,
+				555F2E7C17678A9700E84674 /* FKFlickrPlacesGetTopPlacesList.h */,
+				555F2E7D17678A9700E84674 /* FKFlickrPlacesGetTopPlacesList.m */,
+				555F2E7E17678A9700E84674 /* FKFlickrPlacesPlacesForBoundingBox.h */,
+				555F2E7F17678A9700E84674 /* FKFlickrPlacesPlacesForBoundingBox.m */,
+				555F2E8017678A9700E84674 /* FKFlickrPlacesPlacesForContacts.h */,
+				555F2E8117678A9700E84674 /* FKFlickrPlacesPlacesForContacts.m */,
+				555F2E8217678A9700E84674 /* FKFlickrPlacesPlacesForTags.h */,
+				555F2E8317678A9700E84674 /* FKFlickrPlacesPlacesForTags.m */,
+				555F2E8417678A9800E84674 /* FKFlickrPlacesPlacesForUser.h */,
+				555F2E8517678A9800E84674 /* FKFlickrPlacesPlacesForUser.m */,
+				555F2E8617678A9800E84674 /* FKFlickrPlacesResolvePlaceId.h */,
+				555F2E8717678A9800E84674 /* FKFlickrPlacesResolvePlaceId.m */,
+				555F2E8817678A9800E84674 /* FKFlickrPlacesResolvePlaceURL.h */,
+				555F2E8917678A9800E84674 /* FKFlickrPlacesResolvePlaceURL.m */,
+				555F2E8A17678A9800E84674 /* FKFlickrPlacesTagsForPlace.h */,
+				555F2E8B17678A9800E84674 /* FKFlickrPlacesTagsForPlace.m */,
+			);
+			path = Places;
+			sourceTree = "<group>";
+		};
+		555F2E8C17678A9800E84674 /* Prefs */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E8D17678A9800E84674 /* FKFlickrPrefsGetContentType.h */,
+				555F2E8E17678A9800E84674 /* FKFlickrPrefsGetContentType.m */,
+				555F2E8F17678A9800E84674 /* FKFlickrPrefsGetGeoPerms.h */,
+				555F2E9017678A9800E84674 /* FKFlickrPrefsGetGeoPerms.m */,
+				555F2E9117678A9800E84674 /* FKFlickrPrefsGetHidden.h */,
+				555F2E9217678A9800E84674 /* FKFlickrPrefsGetHidden.m */,
+				555F2E9317678A9800E84674 /* FKFlickrPrefsGetPrivacy.h */,
+				555F2E9417678A9800E84674 /* FKFlickrPrefsGetPrivacy.m */,
+				555F2E9517678A9800E84674 /* FKFlickrPrefsGetSafetyLevel.h */,
+				555F2E9617678A9800E84674 /* FKFlickrPrefsGetSafetyLevel.m */,
+			);
+			path = Prefs;
+			sourceTree = "<group>";
+		};
+		555F2E9717678A9800E84674 /* Push */ = {
+			isa = PBXGroup;
+			children = (
+				555F2E9817678A9800E84674 /* FKFlickrPushGetSubscriptions.h */,
+				555F2E9917678A9800E84674 /* FKFlickrPushGetSubscriptions.m */,
+				555F2E9A17678A9800E84674 /* FKFlickrPushGetTopics.h */,
+				555F2E9B17678A9800E84674 /* FKFlickrPushGetTopics.m */,
+				555F2E9C17678A9800E84674 /* FKFlickrPushSubscribe.h */,
+				555F2E9D17678A9800E84674 /* FKFlickrPushSubscribe.m */,
+				555F2E9E17678A9800E84674 /* FKFlickrPushUnsubscribe.h */,
+				555F2E9F17678A9800E84674 /* FKFlickrPushUnsubscribe.m */,
+			);
+			path = Push;
+			sourceTree = "<group>";
+		};
+		555F2EA017678A9800E84674 /* Reflection */ = {
+			isa = PBXGroup;
+			children = (
+				555F2EA117678A9800E84674 /* FKFlickrReflectionGetMethodInfo.h */,
+				555F2EA217678A9800E84674 /* FKFlickrReflectionGetMethodInfo.m */,
+				555F2EA317678A9800E84674 /* FKFlickrReflectionGetMethods.h */,
+				555F2EA417678A9800E84674 /* FKFlickrReflectionGetMethods.m */,
+			);
+			path = Reflection;
+			sourceTree = "<group>";
+		};
+		555F2EA517678A9800E84674 /* Stats */ = {
+			isa = PBXGroup;
+			children = (
+				555F2EA617678A9800E84674 /* FKFlickrStatsGetCollectionDomains.h */,
+				555F2EA717678A9800E84674 /* FKFlickrStatsGetCollectionDomains.m */,
+				555F2EA817678A9800E84674 /* FKFlickrStatsGetCollectionReferrers.h */,
+				555F2EA917678A9800E84674 /* FKFlickrStatsGetCollectionReferrers.m */,
+				555F2EAA17678A9800E84674 /* FKFlickrStatsGetCollectionStats.h */,
+				555F2EAB17678A9800E84674 /* FKFlickrStatsGetCollectionStats.m */,
+				555F2EAC17678A9800E84674 /* FKFlickrStatsGetCSVFiles.h */,
+				555F2EAD17678A9800E84674 /* FKFlickrStatsGetCSVFiles.m */,
+				555F2EAE17678A9800E84674 /* FKFlickrStatsGetPhotoDomains.h */,
+				555F2EAF17678A9800E84674 /* FKFlickrStatsGetPhotoDomains.m */,
+				555F2EB017678A9800E84674 /* FKFlickrStatsGetPhotoReferrers.h */,
+				555F2EB117678A9800E84674 /* FKFlickrStatsGetPhotoReferrers.m */,
+				555F2EB217678A9800E84674 /* FKFlickrStatsGetPhotosetDomains.h */,
+				555F2EB317678A9800E84674 /* FKFlickrStatsGetPhotosetDomains.m */,
+				555F2EB417678A9800E84674 /* FKFlickrStatsGetPhotosetReferrers.h */,
+				555F2EB517678A9800E84674 /* FKFlickrStatsGetPhotosetReferrers.m */,
+				555F2EB617678A9800E84674 /* FKFlickrStatsGetPhotosetStats.h */,
+				555F2EB717678A9800E84674 /* FKFlickrStatsGetPhotosetStats.m */,
+				555F2EB817678A9800E84674 /* FKFlickrStatsGetPhotoStats.h */,
+				555F2EB917678A9800E84674 /* FKFlickrStatsGetPhotoStats.m */,
+				555F2EBA17678A9800E84674 /* FKFlickrStatsGetPhotostreamDomains.h */,
+				555F2EBB17678A9800E84674 /* FKFlickrStatsGetPhotostreamDomains.m */,
+				555F2EBC17678A9800E84674 /* FKFlickrStatsGetPhotostreamReferrers.h */,
+				555F2EBD17678A9800E84674 /* FKFlickrStatsGetPhotostreamReferrers.m */,
+				555F2EBE17678A9800E84674 /* FKFlickrStatsGetPhotostreamStats.h */,
+				555F2EBF17678A9800E84674 /* FKFlickrStatsGetPhotostreamStats.m */,
+				555F2EC017678A9800E84674 /* FKFlickrStatsGetPopularPhotos.h */,
+				555F2EC117678A9800E84674 /* FKFlickrStatsGetPopularPhotos.m */,
+				555F2EC217678A9800E84674 /* FKFlickrStatsGetTotalViews.h */,
+				555F2EC317678A9800E84674 /* FKFlickrStatsGetTotalViews.m */,
+			);
+			path = Stats;
+			sourceTree = "<group>";
+		};
+		555F2EC417678A9800E84674 /* Tags */ = {
+			isa = PBXGroup;
+			children = (
+				555F2EC517678A9800E84674 /* FKFlickrTagsGetClusterPhotos.h */,
+				555F2EC617678A9800E84674 /* FKFlickrTagsGetClusterPhotos.m */,
+				555F2EC717678A9800E84674 /* FKFlickrTagsGetClusters.h */,
+				555F2EC817678A9800E84674 /* FKFlickrTagsGetClusters.m */,
+				555F2EC917678A9800E84674 /* FKFlickrTagsGetHotList.h */,
+				555F2ECA17678A9800E84674 /* FKFlickrTagsGetHotList.m */,
+				555F2ECB17678A9800E84674 /* FKFlickrTagsGetListPhoto.h */,
+				555F2ECC17678A9800E84674 /* FKFlickrTagsGetListPhoto.m */,
+				555F2ECD17678A9800E84674 /* FKFlickrTagsGetListUser.h */,
+				555F2ECE17678A9800E84674 /* FKFlickrTagsGetListUser.m */,
+				555F2ECF17678A9800E84674 /* FKFlickrTagsGetListUserPopular.h */,
+				555F2ED017678A9800E84674 /* FKFlickrTagsGetListUserPopular.m */,
+				555F2ED117678A9800E84674 /* FKFlickrTagsGetListUserRaw.h */,
+				555F2ED217678A9800E84674 /* FKFlickrTagsGetListUserRaw.m */,
+				555F2ED317678A9800E84674 /* FKFlickrTagsGetMostFrequentlyUsed.h */,
+				555F2ED417678A9800E84674 /* FKFlickrTagsGetMostFrequentlyUsed.m */,
+				555F2ED517678A9800E84674 /* FKFlickrTagsGetRelated.h */,
+				555F2ED617678A9800E84674 /* FKFlickrTagsGetRelated.m */,
+			);
+			path = Tags;
+			sourceTree = "<group>";
+		};
+		555F2ED717678A9800E84674 /* Test */ = {
+			isa = PBXGroup;
+			children = (
+				555F2ED817678A9800E84674 /* FKFlickrTestEcho.h */,
+				555F2ED917678A9800E84674 /* FKFlickrTestEcho.m */,
+				555F2EDA17678A9800E84674 /* FKFlickrTestLogin.h */,
+				555F2EDB17678A9800E84674 /* FKFlickrTestLogin.m */,
+				555F2EDC17678A9800E84674 /* FKFlickrTestNull.h */,
+				555F2EDD17678A9800E84674 /* FKFlickrTestNull.m */,
+			);
+			path = Test;
+			sourceTree = "<group>";
+		};
+		555F2EDE17678A9800E84674 /* Urls */ = {
+			isa = PBXGroup;
+			children = (
+				555F2EDF17678A9800E84674 /* FKFlickrUrlsGetGroup.h */,
+				555F2EE017678A9800E84674 /* FKFlickrUrlsGetGroup.m */,
+				555F2EE117678A9800E84674 /* FKFlickrUrlsGetUserPhotos.h */,
+				555F2EE217678A9800E84674 /* FKFlickrUrlsGetUserPhotos.m */,
+				555F2EE317678A9800E84674 /* FKFlickrUrlsGetUserProfile.h */,
+				555F2EE417678A9800E84674 /* FKFlickrUrlsGetUserProfile.m */,
+				555F2EE517678A9800E84674 /* FKFlickrUrlsLookupGallery.h */,
+				555F2EE617678A9800E84674 /* FKFlickrUrlsLookupGallery.m */,
+				555F2EE717678A9800E84674 /* FKFlickrUrlsLookupGroup.h */,
+				555F2EE817678A9800E84674 /* FKFlickrUrlsLookupGroup.m */,
+				555F2EE917678A9800E84674 /* FKFlickrUrlsLookupUser.h */,
+				555F2EEA17678A9800E84674 /* FKFlickrUrlsLookupUser.m */,
+			);
+			path = Urls;
+			sourceTree = "<group>";
+		};
+		55AD4848175CA0E1004AF85C /* FlickrKit */ = {
+			isa = PBXGroup;
+			children = (
+				55AD48E1175E7561004AF85C /* FlickrKit.m */,
+				55AD4849175CA188004AF85C /* FKDataTypes.h */,
+				55AD484A175CA188004AF85C /* FKDataTypes.m */,
+			);
+			name = FlickrKit;
+			sourceTree = "<group>";
+		};
+		55AEEF4D1756644900B61A3C /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				55AEEF4E1756646400B61A3C /* FKUtilities.h */,
+				55AEEF4F1756646400B61A3C /* FKUtilities.m */,
+				55EA68AB17CAABD40017DDD1 /* FKOFHMACSha1Base64.h */,
+				55EA68AC17CAABD40017DDD1 /* FKOFHMACSha1Base64.m */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
+		5B2B54951831801B00360DAC /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5B2B54961831801B00360DAC /* Foundation.framework */,
+				5B2B54971831801B00360DAC /* CoreData.framework */,
+				5B2B54981831801B00360DAC /* AppKit.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		5B2B54AE1831801C00360DAC /* FlickrKit FrameworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				5B2B54AF1831801C00360DAC /* Supporting Files */,
+			);
+			path = "FlickrKit FrameworkTests";
+			sourceTree = "<group>";
+		};
+		5B2B54AF1831801C00360DAC /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				5B2B54B01831801C00360DAC /* FlickrKitTests-Info OS X.plist */,
+				5B2B54B11831801C00360DAC /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		5B4ED7D318391C8800745B36 /* FlickrKit OS X */ = {
+			isa = PBXGroup;
+			children = (
+				5B4ED7D418391C8800745B36 /* NSImageJPEGRepresentation.h */,
+				5B4ED7D518391C8800745B36 /* NSImageJPEGRepresentation.m */,
+			);
+			path = "FlickrKit OS X";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		5B2B548F1831801B00360DAC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2B55A71831914700360DAC /* FKFlickrActivityUserComments.h in Headers */,
+				5B2B55A81831914700360DAC /* FKFlickrActivityUserPhotos.h in Headers */,
+				5B2B55A91831915300360DAC /* FKFlickrAuthCheckToken.h in Headers */,
+				5B2B55AA1831915300360DAC /* FKFlickrAuthGetFrob.h in Headers */,
+				5B2B55AB1831915300360DAC /* FKFlickrAuthGetFullToken.h in Headers */,
+				5B2B55AC1831915300360DAC /* FKFlickrAuthGetToken.h in Headers */,
+				5B2B55AD1831918700360DAC /* FKFlickrAuthOauthCheckToken.h in Headers */,
+				5B2B55AE1831918700360DAC /* FKFlickrAuthOauthGetAccessToken.h in Headers */,
+				5B2B55AF1831918700360DAC /* FKFlickrBlogsGetList.h in Headers */,
+				5B2B55B01831918700360DAC /* FKFlickrBlogsGetServices.h in Headers */,
+				5B2B55B11831918700360DAC /* FKFlickrBlogsPostPhoto.h in Headers */,
+				5B2B55B21831918700360DAC /* FKFlickrCamerasGetBrandModels.h in Headers */,
+				5B2B55B31831918700360DAC /* FKFlickrCamerasGetBrands.h in Headers */,
+				5B2B55B41831918700360DAC /* FKFlickrCollectionsGetInfo.h in Headers */,
+				5B2B55B51831918700360DAC /* FKFlickrCollectionsGetTree.h in Headers */,
+				5B2B55B61831918700360DAC /* FKFlickrCommonsGetInstitutions.h in Headers */,
+				5B2B55B71831918700360DAC /* FKFlickrContactsGetList.h in Headers */,
+				5B2B55B81831918700360DAC /* FKFlickrContactsGetListRecentlyUploaded.h in Headers */,
+				5B2B55B91831918700360DAC /* FKFlickrContactsGetPublicList.h in Headers */,
+				5B2B55BA1831918700360DAC /* FKFlickrContactsGetTaggingSuggestions.h in Headers */,
+				5B2B55BB1831918700360DAC /* FKFlickrFavoritesAdd.h in Headers */,
+				5B2B55BC1831918700360DAC /* FKFlickrFavoritesGetContext.h in Headers */,
+				5B2B55BD1831918700360DAC /* FKFlickrFavoritesGetList.h in Headers */,
+				5B2B55BE1831918700360DAC /* FKFlickrFavoritesGetPublicList.h in Headers */,
+				5B2B55BF1831918700360DAC /* FKFlickrFavoritesRemove.h in Headers */,
+				5B2B55C01831919500360DAC /* FKFlickrGalleriesAddPhoto.h in Headers */,
+				5B2B55C11831919500360DAC /* FKFlickrGalleriesCreate.h in Headers */,
+				5B2B55C21831919500360DAC /* FKFlickrGalleriesEditMeta.h in Headers */,
+				5B2B55C31831919500360DAC /* FKFlickrGalleriesEditPhoto.h in Headers */,
+				5B2B55C41831919500360DAC /* FKFlickrGalleriesEditPhotos.h in Headers */,
+				5B2B55C51831919500360DAC /* FKFlickrGalleriesGetInfo.h in Headers */,
+				5B2B55C61831919500360DAC /* FKFlickrGalleriesGetList.h in Headers */,
+				5B2B55C71831919500360DAC /* FKFlickrGalleriesGetListForPhoto.h in Headers */,
+				5B2B55C81831919500360DAC /* FKFlickrGalleriesGetPhotos.h in Headers */,
+				5B2B55C9183191C500360DAC /* FKFlickrGroupsDiscussRepliesAdd.h in Headers */,
+				5B2B55CA183191C500360DAC /* FKFlickrGroupsDiscussRepliesDelete.h in Headers */,
+				5B2B55CB183191C500360DAC /* FKFlickrGroupsDiscussRepliesEdit.h in Headers */,
+				5B2B55CC183191C500360DAC /* FKFlickrGroupsDiscussRepliesGetInfo.h in Headers */,
+				5B2B55CD183191C500360DAC /* FKFlickrGroupsDiscussRepliesGetList.h in Headers */,
+				5B2B55CE183191C500360DAC /* FKFlickrGroupsDiscussTopicsAdd.h in Headers */,
+				5B2B55CF183191C500360DAC /* FKFlickrGroupsDiscussTopicsGetInfo.h in Headers */,
+				5B2B55D0183191C500360DAC /* FKFlickrGroupsDiscussTopicsGetList.h in Headers */,
+				5B2B55D1183191C500360DAC /* FKFlickrGroupsBrowse.h in Headers */,
+				5B2B55D2183191C500360DAC /* FKFlickrGroupsGetInfo.h in Headers */,
+				5B2B55D3183191C500360DAC /* FKFlickrGroupsJoin.h in Headers */,
+				5B2B55D4183191C500360DAC /* FKFlickrGroupsJoinRequest.h in Headers */,
+				5B2B55D5183191C500360DAC /* FKFlickrGroupsLeave.h in Headers */,
+				5B2B55D6183191C500360DAC /* FKFlickrGroupsSearch.h in Headers */,
+				5B2B55D7183191C500360DAC /* FKFlickrGroupsMembersGetList.h in Headers */,
+				5B2B55D8183191C500360DAC /* FKFlickrGroupsPoolsAdd.h in Headers */,
+				5B2B55D9183191C500360DAC /* FKFlickrGroupsPoolsGetContext.h in Headers */,
+				5B2B55DA183191C500360DAC /* FKFlickrGroupsPoolsGetGroups.h in Headers */,
+				5B2B55DB183191C500360DAC /* FKFlickrGroupsPoolsGetPhotos.h in Headers */,
+				5B2B55DC183191C500360DAC /* FKFlickrGroupsPoolsRemove.h in Headers */,
+				5B2B55DD183191C500360DAC /* FKFlickrInterestingnessGetList.h in Headers */,
+				5B2B55DE183191C500360DAC /* FKFlickrMachinetagsGetNamespaces.h in Headers */,
+				5B2B55DF183191C500360DAC /* FKFlickrMachinetagsGetPairs.h in Headers */,
+				5B2B55E0183191C500360DAC /* FKFlickrMachinetagsGetPredicates.h in Headers */,
+				5B2B55E1183191C500360DAC /* FKFlickrMachinetagsGetRecentValues.h in Headers */,
+				5B2B55E2183191C500360DAC /* FKFlickrMachinetagsGetValues.h in Headers */,
+				5B2B55E3183191C500360DAC /* FKFlickrPandaGetList.h in Headers */,
+				5B2B55E4183191C500360DAC /* FKFlickrPandaGetPhotos.h in Headers */,
+				5B2B55E5183191C500360DAC /* FKFlickrPeopleFindByEmail.h in Headers */,
+				5B2B55E6183191C500360DAC /* FKFlickrPeopleFindByUsername.h in Headers */,
+				5B2B55E7183191C500360DAC /* FKFlickrPeopleGetGroups.h in Headers */,
+				5B2B55E8183191C500360DAC /* FKFlickrPeopleGetInfo.h in Headers */,
+				5B2B55E9183191C500360DAC /* FKFlickrPeopleGetLimits.h in Headers */,
+				5B2B55EA183191C500360DAC /* FKFlickrPeopleGetPhotos.h in Headers */,
+				5B2B55EB183191C500360DAC /* FKFlickrPeopleGetPhotosOf.h in Headers */,
+				5B2B55EC183191C500360DAC /* FKFlickrPeopleGetPublicGroups.h in Headers */,
+				5B2B55ED183191C500360DAC /* FKFlickrPeopleGetPublicPhotos.h in Headers */,
+				5B2B55EE183191C500360DAC /* FKFlickrPeopleGetUploadStatus.h in Headers */,
+				5B2B55EF183191DA00360DAC /* FKFlickrPhotosCommentsAddComment.h in Headers */,
+				5B2B55F0183191DA00360DAC /* FKFlickrPhotosCommentsDeleteComment.h in Headers */,
+				5B2B55F1183191DA00360DAC /* FKFlickrPhotosCommentsEditComment.h in Headers */,
+				5B2B55F2183191DA00360DAC /* FKFlickrPhotosCommentsGetList.h in Headers */,
+				5B2B55F3183191DA00360DAC /* FKFlickrPhotosCommentsGetRecentForContacts.h in Headers */,
+				5B2B55F4183191E300360DAC /* FKFlickrPhotosAddTags.h in Headers */,
+				5B2B55F5183191E300360DAC /* FKFlickrPhotosDelete.h in Headers */,
+				5B2B55F6183191E300360DAC /* FKFlickrPhotosGetAllContexts.h in Headers */,
+				5B2B55F7183191E300360DAC /* FKFlickrPhotosGetContactsPhotos.h in Headers */,
+				5B2B55F8183191E300360DAC /* FKFlickrPhotosGetContactsPublicPhotos.h in Headers */,
+				5B2B55F9183191E300360DAC /* FKFlickrPhotosGetContext.h in Headers */,
+				5B2B55FA183191E300360DAC /* FKFlickrPhotosGetCounts.h in Headers */,
+				5B2B55FB183191E300360DAC /* FKFlickrPhotosGetExif.h in Headers */,
+				5B2B55FC183191E300360DAC /* FKFlickrPhotosGetFavorites.h in Headers */,
+				5B2B55FD183191E300360DAC /* FKFlickrPhotosGetInfo.h in Headers */,
+				5B2B55FE183191E300360DAC /* FKFlickrPhotosGetNotInSet.h in Headers */,
+				5B2B55FF183191E300360DAC /* FKFlickrPhotosGetPerms.h in Headers */,
+				5B2B5600183191E300360DAC /* FKFlickrPhotosGetRecent.h in Headers */,
+				5B2B5601183191E300360DAC /* FKFlickrPhotosGetSizes.h in Headers */,
+				5B2B5602183191E300360DAC /* FKFlickrPhotosGetUntagged.h in Headers */,
+				5B2B5603183191E300360DAC /* FKFlickrPhotosGetWithGeoData.h in Headers */,
+				5B2B5604183191E300360DAC /* FKFlickrPhotosGetWithoutGeoData.h in Headers */,
+				5B2B5605183191E300360DAC /* FKFlickrPhotosRecentlyUpdated.h in Headers */,
+				5B2B5606183191E300360DAC /* FKFlickrPhotosRemoveTag.h in Headers */,
+				5B2B5607183191E300360DAC /* FKFlickrPhotosSearch.h in Headers */,
+				5B2B5608183191E300360DAC /* FKFlickrPhotosSetContentType.h in Headers */,
+				5B2B5609183191E300360DAC /* FKFlickrPhotosSetDates.h in Headers */,
+				5B2B560A183191E300360DAC /* FKFlickrPhotosSetMeta.h in Headers */,
+				5B2B560B183191E300360DAC /* FKFlickrPhotosSetPerms.h in Headers */,
+				5B2B560C183191E300360DAC /* FKFlickrPhotosSetSafetyLevel.h in Headers */,
+				5B2B560D183191E300360DAC /* FKFlickrPhotosSetTags.h in Headers */,
+				5B2B560E183191FA00360DAC /* FKFlickrPhotosGeoBatchCorrectLocation.h in Headers */,
+				5B2B560F183191FA00360DAC /* FKFlickrPhotosGeoCorrectLocation.h in Headers */,
+				5B2B5610183191FA00360DAC /* FKFlickrPhotosGeoGetLocation.h in Headers */,
+				5B2B5611183191FA00360DAC /* FKFlickrPhotosGeoGetPerms.h in Headers */,
+				5B2B5612183191FA00360DAC /* FKFlickrPhotosGeoPhotosForLocation.h in Headers */,
+				5B2B5613183191FA00360DAC /* FKFlickrPhotosGeoRemoveLocation.h in Headers */,
+				5B2B5614183191FA00360DAC /* FKFlickrPhotosGeoSetContext.h in Headers */,
+				5B2B5615183191FA00360DAC /* FKFlickrPhotosGeoSetLocation.h in Headers */,
+				5B2B5616183191FA00360DAC /* FKFlickrPhotosGeoSetPerms.h in Headers */,
+				5B2B56171831921300360DAC /* FKFlickrPhotosLicensesGetInfo.h in Headers */,
+				5B2B56181831921300360DAC /* FKFlickrPhotosLicensesSetLicense.h in Headers */,
+				5B2B56191831921300360DAC /* FKFlickrPhotosNotesAdd.h in Headers */,
+				5B2B561A1831921300360DAC /* FKFlickrPhotosNotesDelete.h in Headers */,
+				5B2B561B1831921300360DAC /* FKFlickrPhotosNotesEdit.h in Headers */,
+				5B2B561C1831921300360DAC /* FKFlickrPhotosPeopleAdd.h in Headers */,
+				5B2B561D1831921300360DAC /* FKFlickrPhotosPeopleDelete.h in Headers */,
+				5B2B561E1831921300360DAC /* FKFlickrPhotosPeopleDeleteCoords.h in Headers */,
+				5B2B561F1831921300360DAC /* FKFlickrPhotosPeopleEditCoords.h in Headers */,
+				5B2B56201831921300360DAC /* FKFlickrPhotosPeopleGetList.h in Headers */,
+				5B2B56211831921300360DAC /* FKFlickrPhotosSuggestionsApproveSuggestion.h in Headers */,
+				5B2B56221831921300360DAC /* FKFlickrPhotosSuggestionsGetList.h in Headers */,
+				5B2B56231831921300360DAC /* FKFlickrPhotosSuggestionsRejectSuggestion.h in Headers */,
+				5B2B56241831921300360DAC /* FKFlickrPhotosSuggestionsRemoveSuggestion.h in Headers */,
+				5B2B56251831921300360DAC /* FKFlickrPhotosSuggestionsSuggestLocation.h in Headers */,
+				5B2B56261831921300360DAC /* FKFlickrPhotosTransformRotate.h in Headers */,
+				5B2B56271831921300360DAC /* FKFlickrPhotosUploadCheckTickets.h in Headers */,
+				5B2B56281831921300360DAC /* FKFlickrPhotosetsCommentsAddComment.h in Headers */,
+				5B2B56291831921300360DAC /* FKFlickrPhotosetsCommentsDeleteComment.h in Headers */,
+				5B2B562A1831921300360DAC /* FKFlickrPhotosetsCommentsEditComment.h in Headers */,
+				5B2B562B1831921300360DAC /* FKFlickrPhotosetsCommentsGetList.h in Headers */,
+				5B2B562C1831922B00360DAC /* FKFlickrPhotosetsAddPhoto.h in Headers */,
+				5B2B562D1831922B00360DAC /* FKFlickrPhotosetsCreate.h in Headers */,
+				5B2B562E1831922B00360DAC /* FKFlickrPhotosetsDelete.h in Headers */,
+				5B2B562F1831922B00360DAC /* FKFlickrPhotosetsEditMeta.h in Headers */,
+				5B2B56301831922B00360DAC /* FKFlickrPhotosetsEditPhotos.h in Headers */,
+				5B2B56311831922B00360DAC /* FKFlickrPhotosetsGetContext.h in Headers */,
+				5B2B56321831922B00360DAC /* FKFlickrPhotosetsGetInfo.h in Headers */,
+				5B2B56331831922B00360DAC /* FKFlickrPhotosetsGetList.h in Headers */,
+				5B2B56341831922B00360DAC /* FKFlickrPhotosetsGetPhotos.h in Headers */,
+				5B2B56351831922B00360DAC /* FKFlickrPhotosetsOrderSets.h in Headers */,
+				5B2B56361831922B00360DAC /* FKFlickrPhotosetsRemovePhoto.h in Headers */,
+				5B2B56371831922B00360DAC /* FKFlickrPhotosetsRemovePhotos.h in Headers */,
+				5B2B56381831922B00360DAC /* FKFlickrPhotosetsReorderPhotos.h in Headers */,
+				5B2B56391831922B00360DAC /* FKFlickrPhotosetsSetPrimaryPhoto.h in Headers */,
+				5B2B563A1831923C00360DAC /* FKFlickrPlacesFind.h in Headers */,
+				5B2B563B1831923C00360DAC /* FKFlickrPlacesFindByLatLon.h in Headers */,
+				5B2B563C1831923C00360DAC /* FKFlickrPlacesGetChildrenWithPhotosPublic.h in Headers */,
+				5B2B563D1831923C00360DAC /* FKFlickrPlacesGetInfo.h in Headers */,
+				5B2B563E1831923C00360DAC /* FKFlickrPlacesGetInfoByUrl.h in Headers */,
+				5B2B563F1831923C00360DAC /* FKFlickrPlacesGetPlaceTypes.h in Headers */,
+				5B2B56401831923C00360DAC /* FKFlickrPlacesGetShapeHistory.h in Headers */,
+				5B2B56411831923C00360DAC /* FKFlickrPlacesGetTopPlacesList.h in Headers */,
+				5B2B56421831923C00360DAC /* FKFlickrPlacesPlacesForBoundingBox.h in Headers */,
+				5B2B56431831923C00360DAC /* FKFlickrPlacesPlacesForContacts.h in Headers */,
+				5B2B56441831923C00360DAC /* FKFlickrPlacesPlacesForTags.h in Headers */,
+				5B2B56451831923C00360DAC /* FKFlickrPlacesPlacesForUser.h in Headers */,
+				5B2B56461831923C00360DAC /* FKFlickrPlacesResolvePlaceId.h in Headers */,
+				5B2B56471831923C00360DAC /* FKFlickrPlacesResolvePlaceURL.h in Headers */,
+				5B2B56481831923C00360DAC /* FKFlickrPlacesTagsForPlace.h in Headers */,
+				5B2B56491831924A00360DAC /* FKFlickrPrefsGetContentType.h in Headers */,
+				5B2B564A1831924A00360DAC /* FKFlickrPrefsGetGeoPerms.h in Headers */,
+				5B2B564B1831924A00360DAC /* FKFlickrPrefsGetHidden.h in Headers */,
+				5B2B564C1831924A00360DAC /* FKFlickrPrefsGetPrivacy.h in Headers */,
+				5B2B564D1831924A00360DAC /* FKFlickrPrefsGetSafetyLevel.h in Headers */,
+				5B2B564E1831925300360DAC /* FKFlickrPushGetSubscriptions.h in Headers */,
+				5B2B564F1831925300360DAC /* FKFlickrPushGetTopics.h in Headers */,
+				5B2B56501831925300360DAC /* FKFlickrPushSubscribe.h in Headers */,
+				5B2B56511831925300360DAC /* FKFlickrPushUnsubscribe.h in Headers */,
+				5B2B56541831927200360DAC /* FKFlickrStatsGetCollectionDomains.h in Headers */,
+				5B2B56551831927200360DAC /* FKFlickrStatsGetCollectionReferrers.h in Headers */,
+				5B2B56561831927200360DAC /* FKFlickrStatsGetCollectionStats.h in Headers */,
+				5B2B56571831927200360DAC /* FKFlickrStatsGetCSVFiles.h in Headers */,
+				5B2B56581831927200360DAC /* FKFlickrStatsGetPhotoDomains.h in Headers */,
+				5B2B56591831927200360DAC /* FKFlickrStatsGetPhotoReferrers.h in Headers */,
+				5B2B565A1831927200360DAC /* FKFlickrStatsGetPhotosetDomains.h in Headers */,
+				5B2B565B1831927200360DAC /* FKFlickrStatsGetPhotosetReferrers.h in Headers */,
+				5B2B565C1831927200360DAC /* FKFlickrStatsGetPhotosetStats.h in Headers */,
+				5B2B565D1831927200360DAC /* FKFlickrStatsGetPhotoStats.h in Headers */,
+				5B2B565E1831927200360DAC /* FKFlickrStatsGetPhotostreamDomains.h in Headers */,
+				5B2B565F1831927200360DAC /* FKFlickrStatsGetPhotostreamReferrers.h in Headers */,
+				5B2B56601831927200360DAC /* FKFlickrStatsGetPhotostreamStats.h in Headers */,
+				5B2B56611831927200360DAC /* FKFlickrStatsGetPopularPhotos.h in Headers */,
+				5B2B56621831927200360DAC /* FKFlickrStatsGetTotalViews.h in Headers */,
+				5B2B56631831927200360DAC /* FKFlickrTagsGetClusterPhotos.h in Headers */,
+				5B2B56641831927200360DAC /* FKFlickrTagsGetClusters.h in Headers */,
+				5B2B56651831927200360DAC /* FKFlickrTagsGetHotList.h in Headers */,
+				5B2B56661831927200360DAC /* FKFlickrTagsGetListPhoto.h in Headers */,
+				5B2B56671831927200360DAC /* FKFlickrTagsGetListUser.h in Headers */,
+				5B2B56681831927200360DAC /* FKFlickrTagsGetListUserPopular.h in Headers */,
+				5B2B56691831927200360DAC /* FKFlickrTagsGetListUserRaw.h in Headers */,
+				5B2B566A1831927200360DAC /* FKFlickrTagsGetMostFrequentlyUsed.h in Headers */,
+				5B2B566B1831927200360DAC /* FKFlickrTagsGetRelated.h in Headers */,
+				5B2B566C1831927200360DAC /* FKFlickrTestEcho.h in Headers */,
+				5B2B566D1831927200360DAC /* FKFlickrTestLogin.h in Headers */,
+				5B2B566E1831927200360DAC /* FKFlickrTestNull.h in Headers */,
+				5B2B566F1831927200360DAC /* FKFlickrUrlsGetGroup.h in Headers */,
+				5B2B56701831927200360DAC /* FKFlickrUrlsGetUserPhotos.h in Headers */,
+				5B2B56711831927200360DAC /* FKFlickrUrlsGetUserProfile.h in Headers */,
+				5B2B56721831927200360DAC /* FKFlickrUrlsLookupGallery.h in Headers */,
+				5B2B56731831927200360DAC /* FKFlickrUrlsLookupGroup.h in Headers */,
+				5B2B56741831927200360DAC /* FKFlickrUrlsLookupUser.h in Headers */,
+				5B2B56531831925C00360DAC /* FKFlickrReflectionGetMethods.h in Headers */,
+				5B2B56521831925C00360DAC /* FKFlickrReflectionGetMethodInfo.h in Headers */,
+				5B2B56751831929100360DAC /* FKFlickrAPIMethod.h in Headers */,
+				5B2B56761831929100360DAC /* FKAPIMethods.h in Headers */,
+				5B2B56771831929100360DAC /* FKUtilities.h in Headers */,
+				5B2B56781831929100360DAC /* FKOFHMACSha1Base64.h in Headers */,
+				5B2B56791831929100360DAC /* FKDUDiskCache.h in Headers */,
+				5B2B567A1831929100360DAC /* FKDUDefaultDiskCache.h in Headers */,
+				5B2B567B1831929100360DAC /* FKDUBlocks.h in Headers */,
+				5B2B567C1831929100360DAC /* FKDUConcurrentOperation.h in Headers */,
+				5B2B567D1831929100360DAC /* FKDUNetworkOperation.h in Headers */,
+				5B2B567E1831929100360DAC /* FKDUNetworkController.h in Headers */,
+				5B2B567F1831929100360DAC /* FKDUStreamUtil.h in Headers */,
+				5B2B56801831929100360DAC /* FKFlickrNetworkOperation.h in Headers */,
+				5B4ED7D618391C8800745B36 /* NSImageJPEGRepresentation.h in Headers */,
+				5B2B56811831929100360DAC /* FKImageUploadNetworkOperation.h in Headers */,
+				5B2B56821831929100360DAC /* FKUploadRespone.h in Headers */,
+				5B2B56831831929100360DAC /* FKURLBuilder.h in Headers */,
+				5B2B56841831929100360DAC /* FKDUReachability.h in Headers */,
+				5B2B56851831929100360DAC /* FKDataTypes.h in Headers */,
+				5B2B56871831929100360DAC /* FlickrKitUtilTests.h in Headers */,
+				5B2B56881831929100360DAC /* FlickrKit_Tests.h in Headers */,
+				5B2B56891831929100360DAC /* FlickrKitTests.h in Headers */,
+				5B2B568A1831929100360DAC /* FlickrKitFailTests.h in Headers */,
+				5B2B568B1831929100360DAC /* FlickrAuthTests.h in Headers */,
+				5B2B56861831929100360DAC /* FlickrKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		5B2B54911831801B00360DAC /* FlickrKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B2B54BA1831801C00360DAC /* Build configuration list for PBXNativeTarget "FlickrKit" */;
+			buildPhases = (
+				5B2B548D1831801B00360DAC /* Sources */,
+				5B2B548E1831801B00360DAC /* Frameworks */,
+				5B2B548F1831801B00360DAC /* Headers */,
+				5B2B54901831801B00360DAC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FlickrKit;
+			productName = "FlickrKit Framework";
+			productReference = 5B2B54921831801B00360DAC /* FlickrKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5B2B54A61831801B00360DAC /* FlickrKit FrameworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B2B54BB1831801C00360DAC /* Build configuration list for PBXNativeTarget "FlickrKit FrameworkTests" */;
+			buildPhases = (
+				5B2B54A31831801B00360DAC /* Sources */,
+				5B2B54A41831801B00360DAC /* Frameworks */,
+				5B2B54A51831801B00360DAC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5B2B54AC1831801C00360DAC /* PBXTargetDependency */,
+			);
+			name = "FlickrKit FrameworkTests";
+			productName = "FlickrKit FrameworkTests";
+			productReference = 5B2B54A71831801B00360DAC /* FlickrKit FrameworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		552D910E1753951300BE3FEA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = FK;
+				LastUpgradeCheck = 0460;
+				ORGANIZATIONNAME = "DevedUp Ltd";
+				TargetAttributes = {
+					5B2B54A61831801B00360DAC = {
+						TestTargetID = 5B2B54911831801B00360DAC;
+					};
+				};
+			};
+			buildConfigurationList = 552D91111753951300BE3FEA /* Build configuration list for PBXProject "FlickrKit OS X" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 552D910D1753951300BE3FEA;
+			productRefGroup = 552D91171753951300BE3FEA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5B2B54911831801B00360DAC /* FlickrKit */,
+				5B2B54A61831801B00360DAC /* FlickrKit FrameworkTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5B2B54901831801B00360DAC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2B549E1831801B00360DAC /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B2B54A51831801B00360DAC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2B54B31831801C00360DAC /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5B2B548D1831801B00360DAC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2B55A11831910500360DAC /* FKFlickrUrlsGetGroup.m in Sources */,
+				5B2B55A21831910500360DAC /* FKFlickrUrlsGetUserPhotos.m in Sources */,
+				5B2B55A31831910500360DAC /* FKFlickrUrlsGetUserProfile.m in Sources */,
+				5B2B55A41831910500360DAC /* FKFlickrUrlsLookupGallery.m in Sources */,
+				5B2B55A51831910500360DAC /* FKFlickrUrlsLookupGroup.m in Sources */,
+				5B2B55A61831910500360DAC /* FKFlickrUrlsLookupUser.m in Sources */,
+				5B2B5595183190EC00360DAC /* FKFlickrTagsGetClusterPhotos.m in Sources */,
+				5B2B5596183190EC00360DAC /* FKFlickrTagsGetClusters.m in Sources */,
+				5B2B5597183190EC00360DAC /* FKFlickrTagsGetHotList.m in Sources */,
+				5B2B5598183190EC00360DAC /* FKFlickrTagsGetListPhoto.m in Sources */,
+				5B2B5599183190EC00360DAC /* FKFlickrTagsGetListUser.m in Sources */,
+				5B2B559A183190EC00360DAC /* FKFlickrTagsGetListUserPopular.m in Sources */,
+				5B2B559B183190EC00360DAC /* FKFlickrTagsGetListUserRaw.m in Sources */,
+				5B2B559C183190EC00360DAC /* FKFlickrTagsGetMostFrequentlyUsed.m in Sources */,
+				5B2B559D183190EC00360DAC /* FKFlickrTagsGetRelated.m in Sources */,
+				5B2B54BD183182A800360DAC /* FKImageUploadNetworkOperation.m in Sources */,
+				5B2B54C11831882300360DAC /* FKUtilities.m in Sources */,
+				5B2B54C21831882E00360DAC /* FKDataTypes.m in Sources */,
+				5B2B54C31831884C00360DAC /* FKDUStreamUtil.m in Sources */,
+				5B2B54BC1831825D00360DAC /* FKDUDefaultDiskCache.m in Sources */,
+				5B2B54C41831885900360DAC /* FKDUNetworkOperation.m in Sources */,
+				5B2B54C61831887E00360DAC /* FKURLBuilder.m in Sources */,
+				5B2B54C71831888300360DAC /* FKUploadRespone.m in Sources */,
+				5B2B54C9183188D200360DAC /* FKOFHMACSha1Base64.m in Sources */,
+				5B2B54C81831888700360DAC /* FKFlickrNetworkOperation.m in Sources */,
+				5B2B54CA183188E300360DAC /* FKDUConcurrentOperation.m in Sources */,
+				5B2B54CB183188F300360DAC /* FKDUNetworkController.m in Sources */,
+				5B2B54CC1831890E00360DAC /* FlickrKit.m in Sources */,
+				5B2B54CE18318AD000360DAC /* FKDUReachability.m in Sources */,
+				5B2B54CD18318A2200360DAC /* FKDUBlocks.m in Sources */,
+				5B2B54D918318EF600360DAC /* FKFlickrActivityUserComments.m in Sources */,
+				5B2B54DA18318EF600360DAC /* FKFlickrActivityUserPhotos.m in Sources */,
+				5B2B54DB18318F0400360DAC /* FKFlickrAuthCheckToken.m in Sources */,
+				5B2B54DC18318F0400360DAC /* FKFlickrAuthGetFrob.m in Sources */,
+				5B2B54DD18318F0400360DAC /* FKFlickrAuthGetFullToken.m in Sources */,
+				5B2B54DE18318F0400360DAC /* FKFlickrAuthGetToken.m in Sources */,
+				5B2B54DF18318F0400360DAC /* FKFlickrAuthOauthCheckToken.m in Sources */,
+				5B2B54E018318F0400360DAC /* FKFlickrAuthOauthGetAccessToken.m in Sources */,
+				5B2B54F618318F6B00360DAC /* FKFlickrBlogsGetList.m in Sources */,
+				5B2B54F718318F6B00360DAC /* FKFlickrBlogsGetServices.m in Sources */,
+				5B2B54F818318F6B00360DAC /* FKFlickrBlogsPostPhoto.m in Sources */,
+				5B2B54F918318F6B00360DAC /* FKFlickrCamerasGetBrandModels.m in Sources */,
+				5B2B54FA18318F6B00360DAC /* FKFlickrCamerasGetBrands.m in Sources */,
+				5B2B54EA18318F5300360DAC /* FKFlickrCollectionsGetInfo.m in Sources */,
+				5B2B54EB18318F5300360DAC /* FKFlickrCollectionsGetTree.m in Sources */,
+				5B2B54EC18318F5300360DAC /* FKFlickrCommonsGetInstitutions.m in Sources */,
+				5B2B54ED18318F5300360DAC /* FKFlickrContactsGetList.m in Sources */,
+				5B2B54EE18318F5300360DAC /* FKFlickrContactsGetListRecentlyUploaded.m in Sources */,
+				5B2B54EF18318F5300360DAC /* FKFlickrContactsGetPublicList.m in Sources */,
+				5B2B54F018318F5300360DAC /* FKFlickrContactsGetTaggingSuggestions.m in Sources */,
+				5B2B54F118318F5300360DAC /* FKFlickrFavoritesAdd.m in Sources */,
+				5B2B54F218318F5300360DAC /* FKFlickrFavoritesGetContext.m in Sources */,
+				5B2B54F318318F5300360DAC /* FKFlickrFavoritesGetList.m in Sources */,
+				5B2B54F418318F5300360DAC /* FKFlickrFavoritesGetPublicList.m in Sources */,
+				5B2B54F518318F5300360DAC /* FKFlickrFavoritesRemove.m in Sources */,
+				5B2B54E118318F3400360DAC /* FKFlickrGalleriesAddPhoto.m in Sources */,
+				5B2B54E218318F3400360DAC /* FKFlickrGalleriesCreate.m in Sources */,
+				5B2B54E318318F3400360DAC /* FKFlickrGalleriesEditMeta.m in Sources */,
+				5B2B54E418318F3400360DAC /* FKFlickrGalleriesEditPhoto.m in Sources */,
+				5B2B54E518318F3400360DAC /* FKFlickrGalleriesEditPhotos.m in Sources */,
+				5B2B54E618318F3400360DAC /* FKFlickrGalleriesGetInfo.m in Sources */,
+				5B2B54E718318F3400360DAC /* FKFlickrGalleriesGetList.m in Sources */,
+				5B2B54E818318F3400360DAC /* FKFlickrGalleriesGetListForPhoto.m in Sources */,
+				5B2B54E918318F3400360DAC /* FKFlickrGalleriesGetPhotos.m in Sources */,
+				5B2B54FB18318F9700360DAC /* FKFlickrGroupsDiscussRepliesAdd.m in Sources */,
+				5B2B54FC18318F9700360DAC /* FKFlickrGroupsDiscussRepliesDelete.m in Sources */,
+				5B2B54FD18318F9700360DAC /* FKFlickrGroupsDiscussRepliesEdit.m in Sources */,
+				5B2B54FE18318F9700360DAC /* FKFlickrGroupsDiscussRepliesGetInfo.m in Sources */,
+				5B2B54FF18318F9700360DAC /* FKFlickrGroupsDiscussRepliesGetList.m in Sources */,
+				5B2B550018318F9700360DAC /* FKFlickrGroupsDiscussTopicsAdd.m in Sources */,
+				5B2B550118318F9700360DAC /* FKFlickrGroupsDiscussTopicsGetInfo.m in Sources */,
+				5B2B550218318F9700360DAC /* FKFlickrGroupsDiscussTopicsGetList.m in Sources */,
+				5B2B550318318F9700360DAC /* FKFlickrGroupsBrowse.m in Sources */,
+				5B2B550418318F9700360DAC /* FKFlickrGroupsGetInfo.m in Sources */,
+				5B2B550518318F9700360DAC /* FKFlickrGroupsJoin.m in Sources */,
+				5B2B550618318F9700360DAC /* FKFlickrGroupsJoinRequest.m in Sources */,
+				5B2B550718318F9700360DAC /* FKFlickrGroupsLeave.m in Sources */,
+				5B2B550818318F9700360DAC /* FKFlickrGroupsSearch.m in Sources */,
+				5B2B550918318FC200360DAC /* FKFlickrGroupsMembersGetList.m in Sources */,
+				5B2B550A18318FC200360DAC /* FKFlickrGroupsPoolsAdd.m in Sources */,
+				5B2B550B18318FC200360DAC /* FKFlickrGroupsPoolsGetContext.m in Sources */,
+				5B2B550C18318FC200360DAC /* FKFlickrGroupsPoolsGetGroups.m in Sources */,
+				5B2B550D18318FC200360DAC /* FKFlickrGroupsPoolsGetPhotos.m in Sources */,
+				5B2B550E18318FC200360DAC /* FKFlickrGroupsPoolsRemove.m in Sources */,
+				5B2B550F18318FC200360DAC /* FKFlickrInterestingnessGetList.m in Sources */,
+				5B2B551018318FC200360DAC /* FKFlickrMachinetagsGetNamespaces.m in Sources */,
+				5B2B551118318FC200360DAC /* FKFlickrMachinetagsGetPairs.m in Sources */,
+				5B2B551218318FC200360DAC /* FKFlickrMachinetagsGetPredicates.m in Sources */,
+				5B2B551318318FC200360DAC /* FKFlickrMachinetagsGetRecentValues.m in Sources */,
+				5B2B551418318FC200360DAC /* FKFlickrMachinetagsGetValues.m in Sources */,
+				5B2B551518318FC200360DAC /* FKFlickrPandaGetList.m in Sources */,
+				5B2B551618318FC200360DAC /* FKFlickrPandaGetPhotos.m in Sources */,
+				5B2B551718318FC200360DAC /* FKFlickrPeopleFindByEmail.m in Sources */,
+				5B2B551818318FC200360DAC /* FKFlickrPeopleFindByUsername.m in Sources */,
+				5B2B551918318FC200360DAC /* FKFlickrPeopleGetGroups.m in Sources */,
+				5B2B551A18318FC200360DAC /* FKFlickrPeopleGetInfo.m in Sources */,
+				5B2B551B18318FC200360DAC /* FKFlickrPeopleGetLimits.m in Sources */,
+				5B2B551C18318FC200360DAC /* FKFlickrPeopleGetPhotos.m in Sources */,
+				5B2B551D18318FC200360DAC /* FKFlickrPeopleGetPhotosOf.m in Sources */,
+				5B4ED7D718391C8800745B36 /* NSImageJPEGRepresentation.m in Sources */,
+				5B2B551E18318FC200360DAC /* FKFlickrPeopleGetPublicGroups.m in Sources */,
+				5B2B551F18318FC200360DAC /* FKFlickrPeopleGetPublicPhotos.m in Sources */,
+				5B2B552018318FC200360DAC /* FKFlickrPeopleGetUploadStatus.m in Sources */,
+				5B2B552118318FF300360DAC /* FKFlickrPhotosCommentsAddComment.m in Sources */,
+				5B2B552218318FF300360DAC /* FKFlickrPhotosCommentsDeleteComment.m in Sources */,
+				5B2B552318318FF300360DAC /* FKFlickrPhotosCommentsEditComment.m in Sources */,
+				5B2B552418318FF300360DAC /* FKFlickrPhotosCommentsGetList.m in Sources */,
+				5B2B552518318FF300360DAC /* FKFlickrPhotosCommentsGetRecentForContacts.m in Sources */,
+				5B2B552618318FF300360DAC /* FKFlickrPhotosAddTags.m in Sources */,
+				5B2B552718318FF300360DAC /* FKFlickrPhotosDelete.m in Sources */,
+				5B2B552818318FF300360DAC /* FKFlickrPhotosGetAllContexts.m in Sources */,
+				5B2B552918318FF300360DAC /* FKFlickrPhotosGetContactsPhotos.m in Sources */,
+				5B2B552A18318FF300360DAC /* FKFlickrPhotosGetContactsPublicPhotos.m in Sources */,
+				5B2B552B18318FF300360DAC /* FKFlickrPhotosGetContext.m in Sources */,
+				5B2B552C18318FF300360DAC /* FKFlickrPhotosGetCounts.m in Sources */,
+				5B2B552D18318FF300360DAC /* FKFlickrPhotosGetExif.m in Sources */,
+				5B2B552E18318FF300360DAC /* FKFlickrPhotosGetFavorites.m in Sources */,
+				5B2B552F18318FF300360DAC /* FKFlickrPhotosGetInfo.m in Sources */,
+				5B2B553018318FF300360DAC /* FKFlickrPhotosGetNotInSet.m in Sources */,
+				5B2B553118318FF300360DAC /* FKFlickrPhotosGetPerms.m in Sources */,
+				5B2B553218318FF300360DAC /* FKFlickrPhotosGetRecent.m in Sources */,
+				5B2B553318318FF300360DAC /* FKFlickrPhotosGetSizes.m in Sources */,
+				5B2B553418318FF300360DAC /* FKFlickrPhotosGetUntagged.m in Sources */,
+				5B2B553518318FF300360DAC /* FKFlickrPhotosGetWithGeoData.m in Sources */,
+				5B2B553618318FF300360DAC /* FKFlickrPhotosGetWithoutGeoData.m in Sources */,
+				5B2B553718318FF300360DAC /* FKFlickrPhotosRecentlyUpdated.m in Sources */,
+				5B2B553818318FF300360DAC /* FKFlickrPhotosRemoveTag.m in Sources */,
+				5B2B553918318FF300360DAC /* FKFlickrPhotosSearch.m in Sources */,
+				5B2B553A18318FF300360DAC /* FKFlickrPhotosSetContentType.m in Sources */,
+				5B2B553B18318FF300360DAC /* FKFlickrPhotosSetDates.m in Sources */,
+				5B2B553C18318FF300360DAC /* FKFlickrPhotosSetMeta.m in Sources */,
+				5B2B553D18318FF300360DAC /* FKFlickrPhotosSetPerms.m in Sources */,
+				5B2B553E18318FF300360DAC /* FKFlickrPhotosSetSafetyLevel.m in Sources */,
+				5B2B553F18318FF300360DAC /* FKFlickrPhotosSetTags.m in Sources */,
+				5B2B55401831900C00360DAC /* FKFlickrPhotosGeoBatchCorrectLocation.m in Sources */,
+				5B2B55411831900C00360DAC /* FKFlickrPhotosGeoCorrectLocation.m in Sources */,
+				5B2B55421831900C00360DAC /* FKFlickrPhotosGeoGetLocation.m in Sources */,
+				5B2B55431831900C00360DAC /* FKFlickrPhotosGeoGetPerms.m in Sources */,
+				5B2B55441831900C00360DAC /* FKFlickrPhotosGeoPhotosForLocation.m in Sources */,
+				5B2B55451831900C00360DAC /* FKFlickrPhotosGeoRemoveLocation.m in Sources */,
+				5B2B55461831900C00360DAC /* FKFlickrPhotosGeoSetContext.m in Sources */,
+				5B2B55471831900C00360DAC /* FKFlickrPhotosGeoSetLocation.m in Sources */,
+				5B2B55481831900C00360DAC /* FKFlickrPhotosGeoSetPerms.m in Sources */,
+				5B2B55491831901C00360DAC /* FKFlickrPhotosLicensesGetInfo.m in Sources */,
+				5B2B554A1831901C00360DAC /* FKFlickrPhotosLicensesSetLicense.m in Sources */,
+				5B2B554B1831904B00360DAC /* FKFlickrPhotosNotesAdd.m in Sources */,
+				5B2B554C1831904B00360DAC /* FKFlickrPhotosNotesDelete.m in Sources */,
+				5B2B554D1831904B00360DAC /* FKFlickrPhotosNotesEdit.m in Sources */,
+				5B2B554E1831904B00360DAC /* FKFlickrPhotosPeopleAdd.m in Sources */,
+				5B2B554F1831904B00360DAC /* FKFlickrPhotosPeopleDelete.m in Sources */,
+				5B2B55501831904B00360DAC /* FKFlickrPhotosPeopleDeleteCoords.m in Sources */,
+				5B2B55511831904B00360DAC /* FKFlickrPhotosPeopleEditCoords.m in Sources */,
+				5B2B55521831904B00360DAC /* FKFlickrPhotosPeopleGetList.m in Sources */,
+				5B2B55531831906300360DAC /* FKFlickrPhotosSuggestionsApproveSuggestion.m in Sources */,
+				5B2B55541831906300360DAC /* FKFlickrPhotosSuggestionsGetList.m in Sources */,
+				5B2B55551831906300360DAC /* FKFlickrPhotosSuggestionsRejectSuggestion.m in Sources */,
+				5B2B55561831906300360DAC /* FKFlickrPhotosSuggestionsRemoveSuggestion.m in Sources */,
+				5B2B55571831906300360DAC /* FKFlickrPhotosSuggestionsSuggestLocation.m in Sources */,
+				5B2B55581831906300360DAC /* FKFlickrPhotosTransformRotate.m in Sources */,
+				5B2B55591831906300360DAC /* FKFlickrPhotosUploadCheckTickets.m in Sources */,
+				5B2B555A1831908200360DAC /* FKFlickrPhotosetsCommentsAddComment.m in Sources */,
+				5B2B555B1831908200360DAC /* FKFlickrPhotosetsCommentsDeleteComment.m in Sources */,
+				5B2B555C1831908200360DAC /* FKFlickrPhotosetsCommentsEditComment.m in Sources */,
+				5B2B555D1831908200360DAC /* FKFlickrPhotosetsCommentsGetList.m in Sources */,
+				5B2B555E1831908200360DAC /* FKFlickrPhotosetsAddPhoto.m in Sources */,
+				5B2B555F1831908200360DAC /* FKFlickrPhotosetsCreate.m in Sources */,
+				5B2B55601831908200360DAC /* FKFlickrPhotosetsDelete.m in Sources */,
+				5B2B55611831908200360DAC /* FKFlickrPhotosetsEditMeta.m in Sources */,
+				5B2B55621831908200360DAC /* FKFlickrPhotosetsEditPhotos.m in Sources */,
+				5B2B55631831908200360DAC /* FKFlickrPhotosetsGetContext.m in Sources */,
+				5B2B55641831908200360DAC /* FKFlickrPhotosetsGetInfo.m in Sources */,
+				5B2B55651831908200360DAC /* FKFlickrPhotosetsGetList.m in Sources */,
+				5B2B55661831908200360DAC /* FKFlickrPhotosetsGetPhotos.m in Sources */,
+				5B2B55671831908200360DAC /* FKFlickrPhotosetsOrderSets.m in Sources */,
+				5B2B55681831908200360DAC /* FKFlickrPhotosetsRemovePhoto.m in Sources */,
+				5B2B55691831908200360DAC /* FKFlickrPhotosetsRemovePhotos.m in Sources */,
+				5B2B556A1831908200360DAC /* FKFlickrPhotosetsReorderPhotos.m in Sources */,
+				5B2B556B1831908200360DAC /* FKFlickrPhotosetsSetPrimaryPhoto.m in Sources */,
+				5B2B556C183190B500360DAC /* FKFlickrPlacesFind.m in Sources */,
+				5B2B556D183190B500360DAC /* FKFlickrPlacesFindByLatLon.m in Sources */,
+				5B2B556E183190B500360DAC /* FKFlickrPlacesGetChildrenWithPhotosPublic.m in Sources */,
+				5B2B556F183190B500360DAC /* FKFlickrPlacesGetInfo.m in Sources */,
+				5B2B5570183190B500360DAC /* FKFlickrPlacesGetInfoByUrl.m in Sources */,
+				5B2B5571183190B500360DAC /* FKFlickrPlacesGetPlaceTypes.m in Sources */,
+				5B2B5572183190B500360DAC /* FKFlickrPlacesGetShapeHistory.m in Sources */,
+				5B2B5573183190B500360DAC /* FKFlickrPlacesGetTopPlacesList.m in Sources */,
+				5B2B5574183190B500360DAC /* FKFlickrPlacesPlacesForBoundingBox.m in Sources */,
+				5B2B5575183190B500360DAC /* FKFlickrPlacesPlacesForContacts.m in Sources */,
+				5B2B5576183190B500360DAC /* FKFlickrPlacesPlacesForTags.m in Sources */,
+				5B2B5577183190B500360DAC /* FKFlickrPlacesPlacesForUser.m in Sources */,
+				5B2B5578183190B500360DAC /* FKFlickrPlacesResolvePlaceId.m in Sources */,
+				5B2B5579183190B500360DAC /* FKFlickrPlacesResolvePlaceURL.m in Sources */,
+				5B2B557A183190B500360DAC /* FKFlickrPlacesTagsForPlace.m in Sources */,
+				5B2B557B183190B500360DAC /* FKFlickrPrefsGetContentType.m in Sources */,
+				5B2B557C183190B500360DAC /* FKFlickrPrefsGetGeoPerms.m in Sources */,
+				5B2B557D183190B500360DAC /* FKFlickrPrefsGetHidden.m in Sources */,
+				5B2B557E183190B500360DAC /* FKFlickrPrefsGetPrivacy.m in Sources */,
+				5B2B557F183190B500360DAC /* FKFlickrPrefsGetSafetyLevel.m in Sources */,
+				5B2B5580183190B500360DAC /* FKFlickrPushGetSubscriptions.m in Sources */,
+				5B2B5581183190B500360DAC /* FKFlickrPushGetTopics.m in Sources */,
+				5B2B5582183190B500360DAC /* FKFlickrPushSubscribe.m in Sources */,
+				5B2B5583183190B500360DAC /* FKFlickrPushUnsubscribe.m in Sources */,
+				5B2B5584183190B500360DAC /* FKFlickrReflectionGetMethodInfo.m in Sources */,
+				5B2B5585183190B500360DAC /* FKFlickrReflectionGetMethods.m in Sources */,
+				5B2B5586183190DA00360DAC /* FKFlickrStatsGetCollectionDomains.m in Sources */,
+				5B2B5587183190DA00360DAC /* FKFlickrStatsGetCollectionReferrers.m in Sources */,
+				5B2B5588183190DA00360DAC /* FKFlickrStatsGetCollectionStats.m in Sources */,
+				5B2B5589183190DA00360DAC /* FKFlickrStatsGetCSVFiles.m in Sources */,
+				5B2B558A183190DA00360DAC /* FKFlickrStatsGetPhotoDomains.m in Sources */,
+				5B2B558B183190DA00360DAC /* FKFlickrStatsGetPhotoReferrers.m in Sources */,
+				5B2B558C183190DA00360DAC /* FKFlickrStatsGetPhotosetDomains.m in Sources */,
+				5B2B558D183190DA00360DAC /* FKFlickrStatsGetPhotosetReferrers.m in Sources */,
+				5B2B558E183190DA00360DAC /* FKFlickrStatsGetPhotosetStats.m in Sources */,
+				5B2B558F183190DA00360DAC /* FKFlickrStatsGetPhotoStats.m in Sources */,
+				5B2B5590183190DA00360DAC /* FKFlickrStatsGetPhotostreamDomains.m in Sources */,
+				5B2B5591183190DA00360DAC /* FKFlickrStatsGetPhotostreamReferrers.m in Sources */,
+				5B2B5592183190DA00360DAC /* FKFlickrStatsGetPhotostreamStats.m in Sources */,
+				5B2B5593183190DA00360DAC /* FKFlickrStatsGetPopularPhotos.m in Sources */,
+				5B2B5594183190DA00360DAC /* FKFlickrStatsGetTotalViews.m in Sources */,
+				5B2B559E183190FA00360DAC /* FKFlickrTestEcho.m in Sources */,
+				5B2B559F183190FA00360DAC /* FKFlickrTestLogin.m in Sources */,
+				5B2B55A0183190FA00360DAC /* FKFlickrTestNull.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B2B54A31831801B00360DAC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B4ED7DB18391FA100745B36 /* FlickrAuthTests.m in Sources */,
+				5B4ED7D818391FA100745B36 /* FlickrKitUtilTests.m in Sources */,
+				5B4ED7D918391FA100745B36 /* FlickrKitTests.m in Sources */,
+				5B4ED7DA18391FA100745B36 /* FlickrKitFailTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5B2B54AC1831801C00360DAC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B2B54911831801B00360DAC /* FlickrKit */;
+			targetProxy = 5B2B54AB1831801C00360DAC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		5B2B549C1831801B00360DAC /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5B2B549D1831801B00360DAC /* en */,
+			);
+			name = InfoPlist.strings;
+			path = "FlickrKit OS X";
+			sourceTree = SOURCE_ROOT;
+		};
+		5B2B54B11831801C00360DAC /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5B2B54B21831801C00360DAC /* en */,
+			);
+			name = InfoPlist.strings;
+			path = ../FlickrKitTests;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		552D91461753951300BE3FEA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		552D91471753951300BE3FEA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				SDKROOT = macosx;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5B2B54B61831801C00360DAC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FlickrKit OS X/FlickrKit.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "FlickrKit OS X/FlickrKit-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Debug;
+		};
+		5B2B54B71831801C00360DAC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_VERSION = A;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FlickrKit OS X/FlickrKit.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "FlickrKit OS X/FlickrKit-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Release;
+		};
+		5B2B54B81831801C00360DAC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FlickrKit OS X/FlickrKit.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "FlickrKitTests/FlickrKitTests-Info OS X.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		5B2B54B91831801C00360DAC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FlickrKit OS X/FlickrKit.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "FlickrKitTests/FlickrKitTests-Info OS X.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		552D91111753951300BE3FEA /* Build configuration list for PBXProject "FlickrKit OS X" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				552D91461753951300BE3FEA /* Debug */,
+				552D91471753951300BE3FEA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B2B54BA1831801C00360DAC /* Build configuration list for PBXNativeTarget "FlickrKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B2B54B61831801C00360DAC /* Debug */,
+				5B2B54B71831801C00360DAC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B2B54BB1831801C00360DAC /* Build configuration list for PBXNativeTarget "FlickrKit FrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B2B54B81831801C00360DAC /* Debug */,
+				5B2B54B91831801C00360DAC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 552D910E1753951300BE3FEA /* Project object */;
+}

--- a/FlickrKit OS X/FlickrKit-Info.plist
+++ b/FlickrKit OS X/FlickrKit-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.devedup.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2013 DevedUp Ltd. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/FlickrKit OS X/FlickrKit.pch
+++ b/FlickrKit OS X/FlickrKit.pch
@@ -1,0 +1,11 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#import <TargetConditionals.h>
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/FlickrKit OS X/en.lproj/InfoPlist.strings
+++ b/FlickrKit OS X/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/FlickrKitTests/FlickrKitTests-Info OS X.plist
+++ b/FlickrKitTests/FlickrKitTests-Info OS X.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.randomsequence.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Resources/FlickrKit-Prefix.pch
+++ b/Resources/FlickrKit-Prefix.pch
@@ -2,6 +2,8 @@
 // Prefix header for all source files of the 'FlickrKit' target in the 'FlickrKit' project
 //
 
+#import <TargetConditionals.h>
+
 #ifdef __OBJC__
 	#import <Foundation/Foundation.h>
 #endif


### PR DESCRIPTION
Initial port to the Mac. Note the tests don't work (though they don't seem to work on iOS either).

Ref devedup/FlickrKit#2
