### PR TITLE
Add ability to manually login with auth token, and decoupled shared singleton with internals

### DIFF
--- a/Classes/FlickrKit.h
+++ b/Classes/FlickrKit.h
@@ -128,10 +128,13 @@ FOUNDATION_EXPORT const unsigned char FlickrKitVersionString[];
 - (FKDUNetworkOperation *) beginAuthWithCallbackURL:(NSURL *)url permission:(FKPermission)permission completion:(FKAPIAuthBeginCompletion)completion;
 // 2. After they login and authorize the app, need to get an auth token - this will happen via your URL scheme - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
 - (FKDUNetworkOperation *) completeAuthWithURL:(NSURL *)url completion:(FKAPIAuthCompletion)completion;
+- (FKDUNetworkOperation *) completeAuthWithURL:(NSURL *)url saveAuthTokenToUserDefaults:(BOOL)persistAuthToken completion:(FKAPIAuthCompletion)completion;
 // 3. On returning to the app, you want to re-log them in automatically - do it here
 - (FKFlickrNetworkOperation *) checkAuthorizationOnCompletion:(FKAPIAuthCompletion)completion;
 // 4. Logout - just removes all the stored keys
 - (void) logout;
+// 5. Programatic Login - allow logging in with supplied tokens
+- (void) loginWithAuthToken:(NSString *)authToken authSecret:(NSString *)authSecret;
 
 @end
 

--- a/Classes/FlickrKit/FlickrKit.m
+++ b/Classes/FlickrKit/FlickrKit.m
@@ -235,6 +235,11 @@
 }
 
 - (FKDUNetworkOperation *) completeAuthWithURL:(NSURL *)url completion:(FKAPIAuthCompletion)completion {
+    // By default persist token to user defaults
+    return [self completeAuthWithURL:url saveAuthTokenToUserDefaults:YES completion:completion];
+}
+
+- (FKDUNetworkOperation *) completeAuthWithURL:(NSURL *)url saveAuthTokenToUserDefaults:(BOOL)persistAuthToken completion:(FKAPIAuthCompletion)completion {
 	
 	if ([FKDUReachability isOffline]) {
 		if (completion) {
@@ -294,9 +299,11 @@
 						completion(nil, nil, nil, error);
 					}
 				} else {
-					[[NSUserDefaults standardUserDefaults] setValue:oat forKey:kFKStoredTokenKey];
-					[[NSUserDefaults standardUserDefaults] setValue:oats forKey:kFKStoredTokenSecret];
-					[[NSUserDefaults standardUserDefaults] synchronize];
+                    if (persistAuthToken) {
+                        [[NSUserDefaults standardUserDefaults] setValue:oat forKey:kFKStoredTokenKey];
+                        [[NSUserDefaults standardUserDefaults] setValue:oats forKey:kFKStoredTokenSecret];
+                        [[NSUserDefaults standardUserDefaults] synchronize];
+                    }
 					self.authorized = YES;
 					self.authToken = oat;
 					self.authSecret = oats;
@@ -382,6 +389,14 @@
 	self.authSecret = nil;
 	self.authToken = nil;
 	self.beginAuthURL = nil;
+}
+
+#pragma mark - 5. Programatic Login - allow logging in with supplied tokens
+
+- (void) loginWithAuthToken:(NSString *)authToken authSecret:(NSString *)authSecret {
+    self.authorized = YES;
+    self.authToken = authToken;
+    self.authSecret = authSecret;
 }
 
 @end

--- a/Classes/FlickrKit/FlickrKit.m
+++ b/Classes/FlickrKit/FlickrKit.m
@@ -59,11 +59,11 @@
 }
 
 - (FKFlickrNetworkOperation *) call:(NSString *)apiMethod args:(NSDictionary *)requestArgs maxCacheAge:(FKDUMaxAge)maxAge completion:(FKAPIRequestCompletion)completion {
-	NSAssert([FlickrKit sharedFlickrKit].apiKey, @"You must pass an apiKey to initializeWithAPIKey");
+	NSAssert(self.apiKey, @"You must pass an apiKey to initializeWithAPIKey");
 	NSAssert(apiMethod, @"You must pass an apiMethod");
 	NSAssert(completion, @"You must pass a completion block");
 	
-	if ([FKDUReachability isOffline]) {		
+	if ([FKDUReachability isOffline]) {
 		if (completion) {
 			completion(nil, [FKDUReachability buildOfflineErrorMessage]);
 		}
@@ -74,7 +74,7 @@
 		self.diskCache = [FKDUDefaultDiskCache sharedDiskCache];
 	}
 	
-	FKFlickrNetworkOperation *op = [[FKFlickrNetworkOperation alloc] initWithAPIMethod:apiMethod arguments:requestArgs maxAgeMinutes:maxAge diskCache:self.diskCache completion:completion];
+	FKFlickrNetworkOperation *op = [[FKFlickrNetworkOperation alloc] initWithFlickrKit:self APIMethod:apiMethod arguments:requestArgs maxAgeMinutes:maxAge completion:completion];
 	
 	[[FKDUNetworkController sharedController] execute:op];
 	return op;
@@ -87,12 +87,12 @@
 }
 
 - (FKFlickrNetworkOperation *) call:(id<FKFlickrAPIMethod>)method maxCacheAge:(FKDUMaxAge)maxAge completion:(FKAPIRequestCompletion)completion {
-    NSAssert([FlickrKit sharedFlickrKit].apiKey, @"You must pass an apiKey to initializeWithAPIKey");
+    NSAssert(self.apiKey, @"You must pass an apiKey to initializeWithAPIKey");
     NSAssert(method, @"You must pass a method");
 	
 	// Check if this method needs auth
 	if ([method needsLogin]) {
-		if (![FlickrKit sharedFlickrKit].isAuthorized) {
+		if (!self.isAuthorized) {
 			NSString *errorDescription = @"You need to login to call this method";
 			NSDictionary *userInfo = @{NSLocalizedDescriptionKey: errorDescription};
 			NSError *error = [NSError errorWithDomain:FKFlickrAPIErrorDomain code:FKErrorNotAuthorized userInfo:userInfo];
@@ -101,7 +101,7 @@
 		} else {
 			// Check method permission
 			FKPermission permissionRequired = [method requiredPerms];
-			FKPermission grantedPermission = [FlickrKit sharedFlickrKit].permissionGranted;
+			FKPermission grantedPermission = self.permissionGranted;
 			if (permissionRequired > grantedPermission) {
 				NSString *requiredString = FKPermissionStringForPermission(permissionRequired);
 				NSString *grantedString = FKPermissionStringForPermission(grantedPermission);
@@ -126,7 +126,7 @@
 		self.diskCache = [FKDUDefaultDiskCache sharedDiskCache];
 	}
     
-    FKFlickrNetworkOperation *op = [[FKFlickrNetworkOperation alloc] initWithAPIMethod:method maxAgeMinutes:maxAge diskCache:self.diskCache completion:completion];
+    FKFlickrNetworkOperation *op = [[FKFlickrNetworkOperation alloc] initWithFlickrKit:self APIMethod:method maxAgeMinutes:maxAge completion:completion];
 	
 	[[FKDUNetworkController sharedController] execute:op];
 	return op;
@@ -198,7 +198,7 @@
 	}
 	
 	NSDictionary *paramsDictionary = @{@"oauth_callback": [url absoluteString]};
-	FKURLBuilder *urlBuilder = [[FKURLBuilder alloc] init];
+	FKURLBuilder *urlBuilder = [[FKURLBuilder alloc] initWithFlickrKit:self];
     NSURL *requestURL = [urlBuilder oauthURLFromBaseURL:[NSURL URLWithString:@"https://www.flickr.com/services/oauth/request_token"] method:FKHttpMethodGET params:paramsDictionary];
 	
 	FKDUNetworkOperation *op = [[FKDUNetworkOperation alloc] initWithURL:requestURL];
@@ -258,7 +258,7 @@
 	}
     
 	NSDictionary *paramsDictionary = @{@"oauth_token": token, @"oauth_verifier": verifier};
-	FKURLBuilder *urlBuilder = [[FKURLBuilder alloc] init];
+	FKURLBuilder *urlBuilder = [[FKURLBuilder alloc] initWithFlickrKit:self];
     NSURL *requestURL = [urlBuilder oauthURLFromBaseURL:[NSURL URLWithString:@"https://www.flickr.com/services/oauth/access_token"] method:FKHttpMethodGET params:paramsDictionary];
     
 	FKDUNetworkOperation *op = [[FKDUNetworkOperation alloc] initWithURL:requestURL];
@@ -452,16 +452,17 @@
 
 @implementation FlickrKit (PhotoUpload)
 - (FKImageUploadNetworkOperation *) uploadImage:(DUImage *)image args:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion {
-	FKImageUploadNetworkOperation *imageUpload = [[FKImageUploadNetworkOperation alloc] initWithImage:image arguments:args completion:completion];
+    FKImageUploadNetworkOperation *imageUpload = [[FKImageUploadNetworkOperation alloc] initWithFlickrKit:self image:image arguments:args completion:completion];
 	[[FKDUNetworkController sharedController] execute:imageUpload];
     return imageUpload;
 }
 
 #if TARGET_OS_IOS
 - (FKImageUploadNetworkOperation *) uploadAssetURL:(NSURL *)assetURL args:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion {
-    FKImageUploadNetworkOperation *imageUpload = [[FKImageUploadNetworkOperation alloc] initWithAssetURL:assetURL
-                                                                                               arguments:args
-                                                                                              completion:completion];
+    FKImageUploadNetworkOperation *imageUpload = [[FKImageUploadNetworkOperation alloc] initWithFlickrKit:self
+                                                                                                 assetURL:assetURL
+                                                                                                arguments:args
+                                                                                               completion:completion];
     [[FKDUNetworkController sharedController] execute:imageUpload];
     return imageUpload;
 }

--- a/Classes/Network/FKFlickrNetworkOperation.h
+++ b/Classes/Network/FKFlickrNetworkOperation.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 DevedUp Ltd. All rights reserved. http://www.devedup.com
 //
 
+@class FlickrKit;
+
 #import "FKDataTypes.h"
 #import "FKDUConcurrentOperation.h"
 #import "FKDUDiskCache.h"
@@ -14,8 +16,7 @@
 
 @interface FKFlickrNetworkOperation : FKDUNetworkOperation
 
-- (id) initWithAPIMethod:(NSString *)api arguments:(NSDictionary *)args maxAgeMinutes:(FKDUMaxAge)maxAge diskCache:(id<FKDUDiskCache>)diskCache completion:(FKAPIRequestCompletion)completion;
-
-- (id) initWithAPIMethod:(id<FKFlickrAPIMethod>)method maxAgeMinutes:(FKDUMaxAge)maxAge diskCache:(id<FKDUDiskCache>)diskCache completion:(FKAPIRequestCompletion)completion;
+- (id) initWithFlickrKit:(FlickrKit *)flickrKit APIMethod:(NSString *)api arguments:(NSDictionary *)args maxAgeMinutes:(FKDUMaxAge)maxAge completion:(FKAPIRequestCompletion)completion;
+- (id) initWithFlickrKit:(FlickrKit *)flickrKit APIMethod:(id<FKFlickrAPIMethod>)method maxAgeMinutes:(FKDUMaxAge)maxAge completion:(FKAPIRequestCompletion)completion;
 
 @end

--- a/Classes/Network/FKImageUploadNetworkOperation.h
+++ b/Classes/Network/FKImageUploadNetworkOperation.h
@@ -9,13 +9,15 @@
 #import "FKDUNetworkOperation.h"
 #import "FKDataTypes.h"
 
+@class FlickrKit;
+
 @interface FKImageUploadNetworkOperation : FKDUNetworkOperation
 @property (nonatomic, assign, readonly) CGFloat uploadProgress;
 
-- (id) initWithImage:(DUImage *)image arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
+- (id) initWithFlickrKit:(FlickrKit *)flickrKit image:(DUImage *)image arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
 
 #if TARGET_OS_IOS
-- (id) initWithAssetURL:(NSURL *)assetURL arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
+- (id) initWithFlickrKit:(FlickrKit *)flickrKit assetURL:(NSURL *)assetURL arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion;
 #endif
 
 @end

--- a/Classes/Network/FKImageUploadNetworkOperation.m
+++ b/Classes/Network/FKImageUploadNetworkOperation.m
@@ -15,6 +15,7 @@
 
 @interface FKImageUploadNetworkOperation ()
 
+@property (nonatomic, strong) FlickrKit *flickrKit;
 @property (nonatomic, strong) DUImage *image;
 @property (nonatomic, retain) NSString *tempFile;
 @property (nonatomic, copy) FKAPIImageUploadCompletion completion;
@@ -28,9 +29,10 @@
 
 @implementation FKImageUploadNetworkOperation
 
-- (id) initWithImage:(DUImage *)image arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion; {
+- (id) initWithFlickrKit:(FlickrKit *)flickrKit image:(DUImage *)image arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion; {
     self = [super init];
     if (self) {
+        self.flickrKit = flickrKit;
 		self.image = image;
 		self.args = args;
 		self.completion = completion;
@@ -39,9 +41,10 @@
 }
 
 #if TARGET_OS_IOS
-- (id) initWithAssetURL:(NSURL *)assetURL arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion; {
+- (id) initWithFlickrKit:(FlickrKit *)flickrKit assetURL:(NSURL *)assetURL arguments:(NSDictionary *)args completion:(FKAPIImageUploadCompletion)completion; {
     self = [super init];
     if (self) {
+        self.flickrKit = flickrKit;
 		self.image = nil;
         self.assetURL = assetURL;
 		self.args = args;
@@ -93,7 +96,7 @@
 //#endif
     
     // Build a URL to the upload service
-	FKURLBuilder *urlBuilder = [[FKURLBuilder alloc] init];
+	FKURLBuilder *urlBuilder = [[FKURLBuilder alloc] initWithFlickrKit:self.flickrKit];
 	NSDictionary *args = [urlBuilder signedArgsFromParameters:newArgs method:FKHttpMethodPOST url:[NSURL URLWithString:@"https://api.flickr.com/services/upload/"]];
 	
 	// Form multipart needs a boundary 

--- a/Classes/Network/FKURLBuilder.h
+++ b/Classes/Network/FKURLBuilder.h
@@ -11,7 +11,11 @@ typedef enum {
 	FKHttpMethodPOST
 } FKHttpMethod;
 
+@class FlickrKit;
+
 @interface FKURLBuilder : NSObject
+
+- (id)initWithFlickrKit:(FlickrKit *)flickrKit;
 
 #pragma mark - URL Encryption
 

--- a/Classes/Network/FKURLBuilder.m
+++ b/Classes/Network/FKURLBuilder.m
@@ -11,7 +11,27 @@
 #import "FlickrKit.h"
 #import "FKUtilities.h"
 
+@interface FKURLBuilder ()
+@property (nonatomic, strong) FlickrKit *flickrKit;
+@end
+
 @implementation FKURLBuilder
+
+- (id)initWithFlickrKit:(FlickrKit *)flickrKit {
+    self = [super init];
+    if (self) {
+        self.flickrKit = flickrKit;
+    }
+    return self;
+}
+
+- (id)init {
+    self = [super init];
+    if (self) {
+        NSAssert(false, @"FKURLBuilder must be initialised with a FlickrKit instance");
+    }
+    return self;
+}
 
 #pragma mark - URL Encryption
 
@@ -50,17 +70,17 @@
     newArgs[@"oauth_timestamp"] = [NSString stringWithFormat:@"%f", time];
     newArgs[@"oauth_version"] = @"1.0";
     newArgs[@"oauth_signature_method"] = @"HMAC-SHA1";
-    newArgs[@"oauth_consumer_key"] = [FlickrKit sharedFlickrKit].apiKey;
+    newArgs[@"oauth_consumer_key"] = self.flickrKit.apiKey;
     
-    if (!params[@"oauth_token"] && [FlickrKit sharedFlickrKit].authToken) {
-        newArgs[@"oauth_token"] = [FlickrKit sharedFlickrKit].authToken;
+    if (!params[@"oauth_token"] && self.flickrKit.authToken) {
+        newArgs[@"oauth_token"] = self.flickrKit.authToken;
     }
     
     NSString *signatureKey = nil;
-    if ([FlickrKit sharedFlickrKit].authSecret) {
-        signatureKey = [NSString stringWithFormat:@"%@&%@", [FlickrKit sharedFlickrKit].secret, [FlickrKit sharedFlickrKit].authSecret];
+    if (self.flickrKit.authSecret) {
+        signatureKey = [NSString stringWithFormat:@"%@&%@", self.flickrKit.secret, self.flickrKit.authSecret];
     } else {
-        signatureKey = [NSString stringWithFormat:@"%@&", [FlickrKit sharedFlickrKit].secret];
+        signatureKey = [NSString stringWithFormat:@"%@&", self.flickrKit.secret];
     }
     
     NSMutableString *baseString = [NSMutableString string];
@@ -100,12 +120,12 @@
 //private
 - (NSArray *) signedArgumentComponentsFromParameters:(NSDictionary *)params {
     NSMutableDictionary *args = params ? [params mutableCopy] : [NSMutableDictionary dictionary];
-	if ([FlickrKit sharedFlickrKit].apiKey) {
-		args[@"api_key"] = [FlickrKit sharedFlickrKit].apiKey;
+	if (self.flickrKit.apiKey) {
+		args[@"api_key"] = self.flickrKit.apiKey;
 	}
 
 	NSMutableArray *argArray = [NSMutableArray array];
-	NSMutableString *sigString = [NSMutableString stringWithString:[FlickrKit sharedFlickrKit].secret ? [FlickrKit sharedFlickrKit].secret  : @""];
+	NSMutableString *sigString = [NSMutableString stringWithString:self.flickrKit.secret ? self.flickrKit.secret  : @""];
 	NSArray *sortedKeys = [[args allKeys] sortedArrayUsingSelector:@selector(compare:)];
 	
 	for (NSString *key in sortedKeys) {
@@ -123,7 +143,7 @@
 #pragma mark - Args as array
 
 - (NSDictionary *) signedArgsFromParameters:(NSDictionary *)params method:(FKHttpMethod)method url:(NSURL *)url {
-	if ([FlickrKit sharedFlickrKit].isAuthorized) {
+	if (self.flickrKit.isAuthorized) {
 		return [self signedOAuthHTTPQueryParameters:params baseURL:url method:method];
 	} else {
 		NSMutableDictionary *returnDict = [NSMutableDictionary dictionary];


### PR DESCRIPTION
These changes allow me to manage multiple Flickr accounts within one app, and removing any shared dependencies. The default behaviour has not been changed, and the only public changes are:

Allow someone to manually log in with their own token:

```obj-c
- (void) loginWithAuthToken:(NSString *)authToken authSecret:(NSString *)authSecret;
```

And disable persisting of auth token when completing auth, to allow someone to manually grab the tokens after auth is completed and store them how they wish:

```obj-c
- (FKDUNetworkOperation *) completeAuthWithURL:(NSURL *)url completion:(FKAPIAuthCompletion)completion; // Default behaviour retained and token is persisted to user defaults
- (FKDUNetworkOperation *) completeAuthWithURL:(NSURL *)url saveAuthTokenToUserDefaults:(BOOL)persistAuthToken completion:(FKAPIAuthCompletion)completion;
```