### PR TITLE
Fix typo in file name to fix build error

### DIFF
--- a/Classes/Network/FKFlickrNetworkOperation.h
+++ b/Classes/Network/FKFlickrNetworkOperation.h
@@ -9,7 +9,7 @@
 #import "FKDataTypes.h"
 #import "FKDUConcurrentOperation.h"
 #import "FKDUDiskCache.h"
-#import "FKDUnetworkOperation.h"
+#import "FKDUNetworkOperation.h"
 #import "FKFlickrAPIMethod.h"
 
 @interface FKFlickrNetworkOperation : FKDUNetworkOperation

--- a/DemoProject/FlickrKitDemo/FlickrKitDemo-OSX/ViewController.h
+++ b/DemoProject/FlickrKitDemo/FlickrKitDemo-OSX/ViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
-@import FlickrKit.FKDUnetworkOperation;
+@import FlickrKit.FKDUNetworkOperation;
 @interface ViewController : NSViewController
 @end
 


### PR DESCRIPTION
If you use case sensitive filesystem of HFS+,
the header file cannot be found because filesystem distinguish between uppercase and lowercase letters.

Then it will cause the build error.